### PR TITLE
Revert Eigen version to 3.3.7

### DIFF
--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -25,13 +25,21 @@ CPMAddPackage(NAME units
 
 CPMAddPackage(NAME Eigen3
   GITLAB_REPOSITORY "libeigen/eigen"
-  GIT_TAG 3.4.0
+  GIT_TAG 3.3.7
+  DOWNLOAD_ONLY TRUE
   OPTIONS
     "EIGEN_BUILD_DOC FALSE"
     "EIGEN_BUILD_TESTING FALSE"
     "BUILD_TESTING FALSE"
     "EIGEN_BUILD_PKGCONFIG FALSE"
 )
+
+if(Eigen3_ADDED)
+  add_library(Eigen3 INTERFACE IMPORTED GLOBAL)
+  add_library(Eigen3::Eigen ALIAS Eigen3)
+
+  target_include_directories(Eigen3 INTERFACE ${Eigen3_SOURCE_DIR})
+endif()
 
 CPMAddPackage(NAME dlib
   GITHUB_REPOSITORY davisking/dlib


### PR DESCRIPTION
# PR Details
## Description

This PR reverts the Eigen library version from 3.4.0 to 3.3.7. Downstream users of this library (so far only CARMA) currently use 3.3.7, but the 3.4.0 interface is not backwards compatible.

## Related GitHub Issue

Closes #73 

## Related Jira Key

[CDAR-393](https://usdot-carma.atlassian.net/browse/CDAR-393)

## Motivation and Context

See Description

## How Has This Been Tested?

Unit tests were modified in previous changes to prepare for the version change. See #78 and #75.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-393]: https://usdot-carma.atlassian.net/browse/CDAR-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ