### PR TITLE
Update UUID usages

### DIFF
--- a/include/cooperative_perception/fusing.hpp
+++ b/include/cooperative_perception/fusing.hpp
@@ -15,7 +15,8 @@
  */
 
 /*
- * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
+ * Originally developed for Leidos by the Human and Intelligent Vehicle
+ * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
 #ifndef COOPERATIVE_PERCEPTION_FUSING_HPP
@@ -142,13 +143,13 @@ auto fuse_associations(
     // Find the matching detection and track based on their uuids
     for (const auto & track : tracks) {
       const auto track_uuid{get_uuid(track)};
-      if (track_uuid.value() == target_track_uuid) {
+      if (track_uuid == target_track_uuid) {
         for (const auto & detection : detections) {
           const auto detection_uuid{get_uuid(detection)};
           if (
             std::find(
               target_detection_uuids.begin(), target_detection_uuids.end(),
-              detection_uuid.value()) != target_detection_uuids.end()) {
+              detection_uuid) != target_detection_uuids.end()) {
             const auto fused_track{std::visit(fusion_visitor, track, detection)};
             fused_tracks.push_back(fused_track);
           }

--- a/include/cooperative_perception/gating.hpp
+++ b/include/cooperative_perception/gating.hpp
@@ -15,7 +15,8 @@
  */
 
 /*
- * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
+ * Originally developed for Leidos by the Human and Intelligent Vehicle
+ * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
 #ifndef COOPERATIVE_PERCEPTION_GATING_HPP
@@ -30,7 +31,7 @@ namespace cooperative_perception
 template <typename UnaryPredicate>
 auto prune_track_and_detection_scores_if(ScoreMap & scores, UnaryPredicate should_prune) -> void
 {
-  std::vector<std::pair<std::string, std::string>> keys_to_prune;
+  std::vector<std::pair<Uuid, Uuid>> keys_to_prune;
 
   for (const auto & [key, score] : scores) {
     if (should_prune(score)) {

--- a/include/cooperative_perception/scoring.hpp
+++ b/include/cooperative_perception/scoring.hpp
@@ -15,7 +15,8 @@
  */
 
 /*
- * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
+ * Originally developed for Leidos by the Human and Intelligent Vehicle
+ * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
 #ifndef COOPERATIVE_PERCEPTION_SCORING_HPP
@@ -86,7 +87,7 @@ struct mahalanobis_distance_score_fn
 inline constexpr detail::euclidean_distance_score_fn euclidean_distance_score{};
 inline constexpr detail::mahalanobis_distance_score_fn mahalanobis_distance_score{};
 
-using ScoreMap = std::map<std::pair<std::string, std::string>, float>;
+using ScoreMap = std::map<std::pair<Uuid, Uuid>, float>;
 
 template <typename Track, typename Detection, typename Metric>
 auto score_tracks_and_detections(
@@ -102,7 +103,7 @@ auto score_tracks_and_detections(
       const auto detection_uuid{get_uuid(detection)};
 
       if (const auto score = metric(track, detection); score.has_value()) {
-        scores[{track_uuid.value(), detection_uuid.value()}] = score.value();
+        scores[{track_uuid, detection_uuid}] = score.value();
       }
     }
   }

--- a/include/cooperative_perception/track_management.hpp
+++ b/include/cooperative_perception/track_management.hpp
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/*
+ * Originally developed for Leidos by the Human and Intelligent Vehicle
+ * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
+ */
+
 #ifndef COOPERATIVE_PERCEPTION_TRACK_MANAGEMENT_HPP
 #define COOPERATIVE_PERCEPTION_TRACK_MANAGEMENT_HPP
 
@@ -135,8 +140,8 @@ public:
 
 private:
   ManagementPolicy management_policy_;
-  std::unordered_map<std::string, TrackType> tracks_;
-  std::unordered_map<std::string, TrackStatus> track_statuses_;
+  std::unordered_map<Uuid, TrackType> tracks_;
+  std::unordered_map<Uuid, TrackStatus> track_statuses_;
 };
 
 }  // namespace cooperative_perception

--- a/include/cooperative_perception/track_matching.hpp
+++ b/include/cooperative_perception/track_matching.hpp
@@ -15,7 +15,8 @@
  */
 
 /*
- * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
+ * Originally developed for Leidos by the Human and Intelligent Vehicle
+ * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
 #ifndef COOPERATIVE_PERCEPTION_TRACK_MATCHING_HPP
@@ -38,7 +39,7 @@ namespace cooperative_perception
 /**
  * @brief Definition of AssociationMap, which is a mapping of track UUIDs to vectors of detection UUIDs
  */
-using AssociationMap = std::map<std::string, std::vector<std::string>>;
+using AssociationMap = std::map<Uuid, std::vector<Uuid>>;
 
 class isAssociatedDetection
 {
@@ -57,7 +58,7 @@ public:
   }
 
 private:
-  std::unordered_set<std::string> associated_uuids_;
+  std::unordered_set<Uuid> associated_uuids_;
 };
 
 class isAssociatedTrack
@@ -77,7 +78,7 @@ public:
   }
 
 private:
-  std::unordered_set<std::string> associated_uuids_;
+  std::unordered_set<Uuid> associated_uuids_;
 };
 
 /**
@@ -89,7 +90,7 @@ private:
  * @return Score matrix representing the track-detection scores.
  */
 inline auto score_matrix_from_score_map(
-  const ScoreMap & scores, std::set<std::string> & track_set, std::set<std::string> & detection_set)
+  const ScoreMap & scores, std::set<Uuid> & track_set, std::set<Uuid> & detection_set)
   -> dlib::matrix<float>
 {
   std::vector<float> values;
@@ -204,7 +205,7 @@ inline auto get_element_at(const std::set<T> & s, size_t index) -> const T &
  */
 inline auto association_map_from_score_map(
   const ScoreMap & scores, const std::vector<long> & assignments,
-  const std::set<std::string> & track_set, const std::set<std::string> & detection_set)
+  const std::set<Uuid> & track_set, const std::set<Uuid> & detection_set)
   -> AssociationMap
 {
   // Create the AssociationMap
@@ -233,8 +234,8 @@ inline auto association_map_from_score_map(
  */
 inline auto gnn_associator(const ScoreMap & scores) -> AssociationMap
 {
-  std::set<std::string> track_set;
-  std::set<std::string> detection_set;
+  std::set<Uuid> track_set;
+  std::set<Uuid> detection_set;
 
   // Generate the score matrix
   const auto score_matrix = score_matrix_from_score_map(scores, track_set, detection_set);
@@ -260,15 +261,15 @@ inline auto gnn_associator(const ScoreMap & scores) -> AssociationMap
 inline auto print_association_map(const AssociationMap & associations) -> void
 {
   for (const auto & pair : associations) {
-    const std::string & track_uuid = pair.first;
-    const std::vector<std::string> & detection_uuids = pair.second;
+    const Uuid & track_uuid = pair.first;
+    const std::vector<Uuid> & detection_uuids = pair.second;
 
     // Print track UUID
     std::cout << "Track UUID: " << track_uuid << std::endl;
 
     // Print assigned detection UUIDs
     std::cout << "Assigned Detection UUIDs: ";
-    for (const std::string & detection_uuid : detection_uuids) {
+    for (const auto & detection_uuid : detection_uuids) {
       std::cout << detection_uuid << " ";
     }
     std::cout << std::endl << std::endl;

--- a/test/test_fusing.cpp
+++ b/test/test_fusing.cpp
@@ -15,7 +15,8 @@
  */
 
 /*
- * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
+ * Originally developed for Leidos by the Human and Intelligent Vehicle
+ * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
 #include <gmock/gmock.h>
@@ -104,7 +105,9 @@ TEST(TestFusing, CtrvTracksAndDetections)
   using namespace units::literals;
 
   const cp::AssociationMap associations{
-    {"track1", {"detection3"}}, {"track2", {"detection2"}}, {"track3", {"detection1"}}};
+    {cp::Uuid{"track1"}, {cp::Uuid{"detection3"}}},
+    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
+    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
 
   std::ifstream tracks_file{"data/test_fusing_ctrv_tracks_and_detections_tracks.json"};
   ASSERT_TRUE(tracks_file);
@@ -137,7 +140,9 @@ TEST(TestFusing, CtraTracksAndDetections)
   using namespace units::literals;
 
   cp::AssociationMap associations{
-    {"track1", {"detection3"}}, {"track2", {"detection2"}}, {"track3", {"detection1"}}};
+    {cp::Uuid{"track1"}, {cp::Uuid{"detection3"}}},
+    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
+    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
 
   std::ifstream tracks_file{"data/test_fusing_ctra_tracks_and_detections_tracks.json"};
   ASSERT_TRUE(tracks_file);
@@ -170,7 +175,9 @@ TEST(TestFusing, MixedTracksAndDetections)
   using namespace units::literals;
 
   cp::AssociationMap associations{
-    {"track1", {"detection3"}}, {"track2", {"detection2"}}, {"track3", {"detection1"}}};
+    {cp::Uuid{"track1"}, {cp::Uuid{"detection3"}}},
+    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
+    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
 
   std::ifstream tracks_file{"data/test_fusing_mixed_tracks_and_detections_tracks.json"};
   ASSERT_TRUE(tracks_file);
@@ -202,7 +209,9 @@ TEST(TestFusing, UnmatchedAssociations)
 
   // Declaring initial values
   cp::AssociationMap associations{
-    {"track1", {"detection4"}}, {"track2", {"detection5"}}, {"track3", {"detection6"}}};
+    {cp::Uuid{"track1"}, {cp::Uuid{"detection4"}}},
+    {cp::Uuid{"track2"}, {cp::Uuid{"detection5"}}},
+    {cp::Uuid{"track3"}, {cp::Uuid{"detection6"}}}};
 
   std::ifstream tracks_file{"data/test_fusing_unmatched_associations_tracks.json"};
   ASSERT_TRUE(tracks_file);
@@ -230,7 +239,9 @@ TEST(TestFusing, PartialMatchedAssociations)
   using namespace units::literals;
 
   cp::AssociationMap associations{
-    {"track1", {"detection4"}}, {"track2", {"detection2"}}, {"track3", {"detection1"}}};
+    {cp::Uuid{"track1"}, {cp::Uuid{"detection4"}}},
+    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
+    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
 
   std::ifstream tracks_file{"data/test_fusing_partial_matched_associations_tracks.json"};
   ASSERT_TRUE(tracks_file);

--- a/test/test_gating.cpp
+++ b/test/test_gating.cpp
@@ -15,7 +15,8 @@
  */
 
 /*
- * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
+ * Originally developed for Leidos by the Human and Intelligent Vehicle
+ * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
 #include <gtest/gtest.h>
@@ -28,12 +29,13 @@ namespace cp = cooperative_perception;
 TEST(TestGating, TestPruning)
 {
   cp::ScoreMap scores{
-    {{"track1", "detection1"}, 10.0},
-    {{"track2", "detection2"}, 20.0},
-    {{"track3", "detection3"}, 30.0}};
+    {{cp::Uuid{"track1"}, cp::Uuid{"detection1"}}, 10.0},
+    {{cp::Uuid{"track2"}, cp::Uuid{"detection2"}}, 20.0},
+    {{cp::Uuid{"track3"}, cp::Uuid{"detection3"}}, 30.0}};
 
   const cp::ScoreMap expected_pruned_scores{
-    {{"track1", "detection1"}, 10.0}, {{"track2", "detection2"}, 20.0}};
+    {{cp::Uuid{"track1"}, cp::Uuid{"detection1"}}, 10.0},
+    {{cp::Uuid{"track2"}, cp::Uuid{"detection2"}}, 20.0}};
 
   cp::prune_track_and_detection_scores_if(scores, [](const auto & score) { return score > 25.0; });
 

--- a/test/test_scoring.cpp
+++ b/test/test_scoring.cpp
@@ -15,7 +15,8 @@
  */
 
 /*
- * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
+ * Originally developed for Leidos by the Human and Intelligent Vehicle
+ * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
 #include <gtest/gtest.h>
@@ -153,11 +154,11 @@ TEST(TestScoring, TrackToDetectionScoringEuclidean)
     cp::score_tracks_and_detections(tracks, detections, cp::euclidean_distance_score);
 
   const cp::ScoreMap expected_scores{
-    {std::pair{"test_track1", "test_detection1"}, 7.0710678},
-    {std::pair{"test_track1", "test_detection2"}, 5.7445626},
-    {std::pair{"test_track2", "test_detection1"}, 7.2801099},
-    {std::pair{"test_track2", "test_detection2"}, 6.1644139},
-    {std::pair{"test_track3", "test_detection3"}, 0.0},
+    {std::pair{cp::Uuid{"test_track1"}, cp::Uuid{"test_detection1"}}, 7.0710678},
+    {std::pair{cp::Uuid{"test_track1"}, cp::Uuid{"test_detection2"}}, 5.7445626},
+    {std::pair{cp::Uuid{"test_track2"}, cp::Uuid{"test_detection1"}}, 7.2801099},
+    {std::pair{cp::Uuid{"test_track2"}, cp::Uuid{"test_detection2"}}, 6.1644139},
+    {std::pair{cp::Uuid{"test_track3"}, cp::Uuid{"test_detection3"}}, 0.0},
   };
 
   EXPECT_EQ(std::size(scores), std::size(expected_scores));
@@ -225,11 +226,11 @@ TEST(TestScoring, TrackToDetectionScoringMahalanobis)
     cp::score_tracks_and_detections(tracks, detections, cp::mahalanobis_distance_score);
 
   const cp::ScoreMap expected_scores{
-    {std::pair{"test_track1", "test_detection1"}, 122.35757},
-    {std::pair{"test_track1", "test_detection2"}, 90.688416},
-    {std::pair{"test_track2", "test_detection1"}, 109.70312},
-    {std::pair{"test_track2", "test_detection2"}, 95.243896},
-    {std::pair{"test_track3", "test_detection3"}, 0.0},
+    {std::pair{cp::Uuid{"test_track1"}, cp::Uuid{"test_detection1"}}, 122.35757},
+    {std::pair{cp::Uuid{"test_track1"}, cp::Uuid{"test_detection2"}}, 90.688416},
+    {std::pair{cp::Uuid{"test_track2"}, cp::Uuid{"test_detection1"}}, 109.70312},
+    {std::pair{cp::Uuid{"test_track2"}, cp::Uuid{"test_detection2"}}, 95.243896},
+    {std::pair{cp::Uuid{"test_track3"}, cp::Uuid{"test_detection3"}}, 0.0},
   };
 
   EXPECT_EQ(std::size(scores), std::size(expected_scores));

--- a/test/test_track_matching.cpp
+++ b/test/test_track_matching.cpp
@@ -15,7 +15,8 @@
  */
 
 /*
- * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
+ * Originally developed for Leidos by the Human and Intelligent Vehicle
+ * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
 #include <dlib/optimization/max_cost_assignment.h>
@@ -65,14 +66,21 @@ TEST(TestTrackMatching, VerifyLibraryInstallation)
  */
 TEST(TestTrackMatching, GnnAssociator)
 {
-  cp::ScoreMap scores{{{"track1", "detection1"}, 10},  {{"track1", "detection2"}, 2.0},
-                      {{"track1", "detection3"}, 1.0}, {{"track2", "detection1"}, 2.0},
-                      {{"track2", "detection2"}, 1.0}, {{"track2", "detection3"}, 10.0},
-                      {{"track3", "detection1"}, 3.0}, {{"track3", "detection2"}, 10.0},
-                      {{"track3", "detection3"}, 5.0}};
+  cp::ScoreMap scores{
+    {{cp::Uuid{"track1"}, cp::Uuid{"detection1"}}, 10},
+    {{cp::Uuid{"track1"}, cp::Uuid{"detection2"}}, 2.0},
+    {{cp::Uuid{"track1"}, cp::Uuid{"detection3"}}, 1.0},
+    {{cp::Uuid{"track2"}, cp::Uuid{"detection1"}}, 2.0},
+    {{cp::Uuid{"track2"}, cp::Uuid{"detection2"}}, 1.0},
+    {{cp::Uuid{"track2"}, cp::Uuid{"detection3"}}, 10.0},
+    {{cp::Uuid{"track3"}, cp::Uuid{"detection1"}}, 3.0},
+    {{cp::Uuid{"track3"}, cp::Uuid{"detection2"}}, 10.0},
+    {{cp::Uuid{"track3"}, cp::Uuid{"detection3"}}, 5.0}};
 
   cp::AssociationMap expected_associations{
-    {"track1", {"detection3"}}, {"track2", {"detection2"}}, {"track3", {"detection1"}}};
+    {cp::Uuid{"track1"}, {cp::Uuid{"detection3"}}},
+    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
+    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
 
   auto result_associations =
     cp::associate_detections_to_tracks(scores, cp::gnn_association_visitor);
@@ -81,14 +89,14 @@ TEST(TestTrackMatching, GnnAssociator)
 
   // Compare expected_associations with result_associations
   for (const auto & pair : expected_associations) {
-    const std::string & track_uuid = pair.first;
-    const std::vector<std::string> & expected_detections = pair.second;
+    const auto & track_uuid = pair.first;
+    const auto & expected_detections = pair.second;
 
     // Check if track_uuid exists in result_associations
     EXPECT_TRUE(result_associations.count(track_uuid) > 0);
 
     // Get the corresponding vector of detections from result_associations
-    const std::vector<std::string> & result_detections = result_associations[track_uuid];
+    const auto & result_detections = result_associations[track_uuid];
 
     // Check if the expected and result detections have the same size
     EXPECT_EQ(std::size(expected_detections), std::size(result_detections));
@@ -108,12 +116,14 @@ TEST(TestTrackMatching, GnnAssociator)
 TEST(TestTrackMatching, GnnAssociatorWithGatedScores)
 {
   cp::ScoreMap scores{
-    {{"track1", "detection3"}, 1.0},
-    {{"track2", "detection2"}, 1.0},
-    {{"track3", "detection1"}, 1.0}};
+    {{cp::Uuid{"track1"}, cp::Uuid{"detection3"}}, 1.0},
+    {{cp::Uuid{"track2"}, cp::Uuid{"detection2"}}, 1.0},
+    {{cp::Uuid{"track3"}, cp::Uuid{"detection1"}}, 1.0}};
 
   cp::AssociationMap expected_associations{
-    {"track1", {"detection3"}}, {"track2", {"detection2"}}, {"track3", {"detection1"}}};
+    {cp::Uuid{"track1"}, {cp::Uuid{"detection3"}}},
+    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
+    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
 
   auto result_associations =
     cp::associate_detections_to_tracks(scores, cp::gnn_association_visitor);
@@ -122,14 +132,14 @@ TEST(TestTrackMatching, GnnAssociatorWithGatedScores)
 
   // Compare expected_associations with result_associations
   for (const auto & pair : expected_associations) {
-    const std::string & track_uuid = pair.first;
-    const std::vector<std::string> & expected_detections = pair.second;
+    const auto & track_uuid = pair.first;
+    const auto & expected_detections = pair.second;
 
     // Check if track_uuid exists in result_associations
     EXPECT_TRUE(result_associations.count(track_uuid) > 0);
 
     // Get the corresponding vector of detections from result_associations
-    const std::vector<std::string> & result_detections = result_associations[track_uuid];
+    const auto & result_detections = result_associations[track_uuid];
 
     // Check if the expected and result detections have the same size
     EXPECT_EQ(std::size(expected_detections), std::size(result_detections));


### PR DESCRIPTION
# PR Details
## Description

This PR replaces all `std::string` UUID usage with the `Uuid` type because the `DynamicObject` class now uses `Uuid`, not `std::string`. Update unit tests with `Uuid` constructor since it is marked `explicit` and cannot be implicitly created from a `std::string`.

## Related GitHub Issue

Closes #82

## Related Jira Key

Closes [CDAR-415](https://usdot-carma.atlassian.net/browse/CDAR-415)

## Motivation and Context

The `DynamicObject` classes uses the `Uuid` type for its `uuid` filed, but other parts of the codebase still used the old `std::string` implementation. This was causing compilation errors.

## How Has This Been Tested?

Existing unit tests have been updated.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x]  I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
