### PR TITLE
Replace string constants with enumerations

### DIFF
--- a/include/cooperative_perception/track_management.hpp
+++ b/include/cooperative_perception/track_management.hpp
@@ -82,10 +82,10 @@ public:
 
     for (const auto & [uuid, track] : tracks_) {
       if (management_policy_.should_promote(uuid)) {
-        track_statuses_[uuid] = "CONFIRMED";
+        track_statuses_[uuid] = TrackStatus::kConfirmed;
 
       } else if (management_policy_.should_demote(uuid)) {
-        track_statuses_[uuid] = "TENTATIVE";
+        track_statuses_[uuid] = TrackStatus::kTentative;
 
       } else if (management_policy_.should_remove(uuid)) {
         tracks_.erase(uuid);
@@ -98,7 +98,7 @@ public:
   {
     const auto uuid = get_uuid(track);
     tracks_[uuid] = track;
-    track_statuses_[uuid] = "TENTATIVE";
+    track_statuses_[uuid] = TrackStatus::kTentative;
   }
 
   auto get_tentative_tracks() const -> std::vector<TrackType>
@@ -106,7 +106,7 @@ public:
     std::vector<TrackType> tracks;
 
     for (const auto & [uuid, track] : tracks_) {
-      if (track_statuses_[uuid] == "TENTATIVE") {
+      if (track_statuses_.at(uuid) == TrackStatus::kTentative) {
         tracks.emplace_back(track);
       }
     }
@@ -119,7 +119,7 @@ public:
     std::vector<TrackType> tracks;
 
     for (const auto & [uuid, track] : tracks_) {
-      if (track_statuses_[uuid] == "CONFIRMED") {
+      if (track_statuses_.at(uuid) == TrackStatus::kConfirmed) {
         tracks.emplace_back(track);
       }
     }


### PR DESCRIPTION
# PR Details
## Description

The track status values have been changed from `std::string`s to enumerations to provide strong type safety and more robust checks. Enumerations provide better type safety and are less error-prone than string comparisons.

## Related GitHub Issue

Closes #84 

## Related Jira Key

## Motivation and Context

Track statuses have a finite number of options, so they are good candidates for enumerations. The previous method of storing them as strings is less robust.

## How Has This Been Tested?

## Types of changes

- [x] Breaking change (fix or feature that cause existing functionality to change)

Internal change to a class.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.
