### PR TITLE
Replace generic `TrackManager` class

### DIFF
--- a/docs/main.md
+++ b/docs/main.md
@@ -1,0 +1,12 @@
+# Multiple object tracking library
+
+## Track maintenance
+
+### [`multiple_object_tracking::FixedThresholdTrackManager`][fixed_threshold_track_manager_doc]
+
+The templated class [`multiple_object_tracking::FixedThresholdTrackManager`][fixed_threshold_track_manager_doc]
+stores a list of `multiple_object_tracking::Track`s and manages their statuses (_tentative_ or
+_confirmed_) using a fixed-threshold policy.
+
+[fixed_threshold_track_manager_doc]: track_management/fixed_threshold_track_manager/main.md
+

--- a/docs/track_management/fixed_threshold_track_manager/add_tentative_track.md
+++ b/docs/track_management/fixed_threshold_track_manager/add_tentative_track.md
@@ -1,0 +1,15 @@
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::add_tentative_track`
+
+```cpp
+auto add_tentative_track(const Track & track) -> void;
+```
+
+Adds a track to be managed. The track's initial status is _tentative_.
+
+## Parameters
+
+- `track` - the track to be managed
+
+## Return value
+
+(none)

--- a/docs/track_management/fixed_threshold_track_manager/constructor.md
+++ b/docs/track_management/fixed_threshold_track_manager/constructor.md
@@ -1,0 +1,14 @@
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::FixedThresholdTrackManager`
+
+```cpp
+explicit FixedThresholdTrackManager(
+    multiple_object_tracking::PromotionThreshold p,
+    multiple_object_tracking::RemovalThreshold r
+);
+```
+Constructs a `multiple_object_tracking::FixedThresholdTrackManager`.
+
+## Parameters
+
+- `p` - occurrence threshold above which a detection will be promoted to _confirmed_
+- `r` - occurrence threshold below which a detection will be removed from management

--- a/docs/track_management/fixed_threshold_track_manager/destructor.md
+++ b/docs/track_management/fixed_threshold_track_manager/destructor.md
@@ -1,0 +1,7 @@
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::~FixedThresholdTrackManager`
+
+```cpp
+~FixedThresholdTrackManager();
+```
+
+Destructs the `multiple_object_tracking::FixedThresholdTrackManager`.

--- a/docs/track_management/fixed_threshold_track_manager/get_all_tracks.md
+++ b/docs/track_management/fixed_threshold_track_manager/get_all_tracks.md
@@ -1,0 +1,15 @@
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::get_all_tracks`
+
+```cpp
+auto get_all_tracks() const -> std::vector<Track>;
+```
+
+Gets a `std::vector<Track>` of all managed tracks, regardless of their status.
+
+## Parameters
+
+(none)
+
+## Return value
+
+All managed tracks.

--- a/docs/track_management/fixed_threshold_track_manager/get_confirmed_tracks.md
+++ b/docs/track_management/fixed_threshold_track_manager/get_confirmed_tracks.md
@@ -1,0 +1,15 @@
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::get_confirmed_tracks`
+
+```cpp
+auto get_confirmed_tracks() const -> std::vector<Track>;
+```
+
+Gets a `std::vector<Track>` of tracks whose status is _confirmed_.
+
+## Parameters
+
+(none)
+
+## Return value
+
+All managed tracks whose status is _confirmed_.

--- a/docs/track_management/fixed_threshold_track_manager/get_tentative_tracks.md
+++ b/docs/track_management/fixed_threshold_track_manager/get_tentative_tracks.md
@@ -1,0 +1,15 @@
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::get_tentative_tracks`
+
+```cpp
+auto get_tentative_tracks() const -> std::vector<Track>;
+```
+
+Gets a `std::vector<Track>` of tracks whose status is _tentative_.
+
+## Parameters
+
+(none)
+
+## Return value
+
+All managed tracks whose status is _tentative_.

--- a/docs/track_management/fixed_threshold_track_manager/main.md
+++ b/docs/track_management/fixed_threshold_track_manager/main.md
@@ -1,0 +1,45 @@
+# `multiple_object_tracking::FixedThresholdTrackManager`
+
+Defined in header `<multiple_object_tracking/track_management.hpp>`
+
+```cpp
+template <
+    typename Track
+> class FixedThresholdTrackManager;
+```
+
+## Template parameters
+
+- `Track` - The track type being managed.
+
+## Member functions
+
+|                                  |                                             |
+| -------------------------------- | ------------------------------------------- |
+| [(constructor)][constructor_doc] | constructs the `FixedThresholdTrackManager` |
+| [(destructor)][destructor_doc]   | destructs the `FixedThresholdTrackManager`  |
+
+[constructor_doc]: constructor.md
+[destructor_doc]: destructor.md
+
+### Track access
+
+|                                                    |                                                          |
+| -------------------------------------------------- | -------------------------------------------------------- |
+| [`get_tentative_tracks`][get_tentative_tracks_doc] | access a list of tracks whose status is _tentative_      |
+| [`get_confirmed_tracks`][get_confirmed_tracks_doc] | access a list of tracks whose status is _confirmed_      |
+| [`get_all_tracks`][get_all_tracks_doc]             | access a list of all managed tracks regardless of status |
+
+[get_tentative_tracks_doc]: get_tentative_tracks.md
+[get_confirmed_tracks_doc]: get_confirmed_tracks.md
+[get_all_tracks_doc]: get_all_tracks.md
+
+### Modifiers
+
+|                                                  |                                                                         |
+| ------------------------------------------------ | ----------------------------------------------------------------------- |
+| [`update_track_lists`][update_track_lists_doc]   | update each track's status based on the detection-to-track associations |
+| [`add_tentative_track`][add_tentative_track_doc] | add a track to be managed                                               |
+
+[update_track_lists_doc]: update_track_lists.md
+[add_tentative_track_doc]: add_tentative_track.md

--- a/docs/track_management/fixed_threshold_track_manager/update_track_lists.md
+++ b/docs/track_management/fixed_threshold_track_manager/update_track_lists.md
@@ -1,0 +1,15 @@
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::update_track_lists`
+
+```cpp
+auto update_track_lists(const AssociationMap & associations) -> void;
+```
+
+Updates each track's status based on the associations. Each track will either be promoted, demoted, removed, or remain unchanged.
+
+## Parameters
+
+- `associations` - a map of track-to-detection associations indicating the detections associated with each track
+
+## Return value
+
+(none)

--- a/include/cooperative_perception/track_management.hpp
+++ b/include/cooperative_perception/track_management.hpp
@@ -65,13 +65,17 @@ public:
     for (const auto & [uuid, occurrences] : occurrences_) {
       if (occurrences >= promotion_threshold_.value) {
         statuses_[uuid] = TrackStatus::kConfirmed;
-      } else if (occurrences < promotion_threshold_.value) {
-        statuses_[uuid] = TrackStatus::kTentative;
-      } else if (occurrences <= removal_threshold_.value) {
+        continue;
+      }
+
+      if (occurrences <= removal_threshold_.value) {
         tracks_.erase(uuid);
         statuses_.erase(uuid);
         occurrences_.erase(uuid);
+        continue;
       }
+
+      statuses_[uuid] = TrackStatus::kTentative;
     }
   }
 

--- a/include/cooperative_perception/track_management.hpp
+++ b/include/cooperative_perception/track_management.hpp
@@ -36,77 +36,64 @@ struct TaggedType
 using PromotionThreshold = TaggedType<std::size_t, struct PromotionThresholdTag>;
 using RemovalThreshold = TaggedType<std::size_t, struct RemovalThresholdTag>;
 
-class FixedThresholdManagementPolicy
+template <typename Track>
+class FixedThresholdTrackManager
 {
+  enum class TrackStatus
+  {
+    kConfirmed,
+    kTentative
+  };
+
 public:
-  explicit FixedThresholdManagementPolicy(
+  explicit FixedThresholdTrackManager(
     PromotionThreshold promotion_threshold, RemovalThreshold removal_threshold)
   : promotion_threshold_{promotion_threshold}, removal_threshold_{removal_threshold}
   {
   }
 
-  auto update(const AssociationMap & associations) -> void;
-  auto should_promote(const std::string & uuid) const -> bool;
-  auto should_demote(const std::string & uuid) const -> bool;
-  auto should_remove(const std::string & uuid) const -> bool;
-
-private:
-  PromotionThreshold promotion_threshold_;
-  RemovalThreshold removal_threshold_;
-  std::unordered_map<std::string, std::size_t> occurrence_counts;
-};
-
-/**
- * @brief Track status
- *
- * Tracks are tentative until they have been perceived beyond a threshold, at
- * which point they become confirmed.
- */
-enum class TrackStatus
-{
-  kConfirmed,
-  kTentative
-};
-
-template <typename TrackType, typename ManagementPolicy>
-class TrackManager
-{
-public:
-  explicit TrackManager(ManagementPolicy management_policy) : management_policy_{management_policy}
-  {
-  }
-
   auto update_track_lists(const AssociationMap & associations) -> void
   {
-    management_policy_.update(associations);
+    for (auto & [uuid, occurrences] : occurrences_) {
+      if (associations.count(uuid) == 0) {
+        --occurrences;
+      } else {
+        ++occurrences;
+      }
+    }
 
-    for (const auto & [uuid, track] : tracks_) {
-      if (management_policy_.should_promote(uuid)) {
-        track_statuses_[uuid] = TrackStatus::kConfirmed;
-
-      } else if (management_policy_.should_demote(uuid)) {
-        track_statuses_[uuid] = TrackStatus::kTentative;
-
-      } else if (management_policy_.should_remove(uuid)) {
+    for (const auto & [uuid, occurrences] : occurrences_) {
+      if (occurrences >= promotion_threshold_.value) {
+        statuses_[uuid] = TrackStatus::kConfirmed;
+      } else if (occurrences < promotion_threshold_.value) {
+        statuses_[uuid] = TrackStatus::kTentative;
+      } else if (occurrences <= removal_threshold_.value) {
         tracks_.erase(uuid);
-        track_statuses_.erase(uuid);
+        statuses_.erase(uuid);
+        occurrences_.erase(uuid);
       }
     }
   }
 
-  auto add_tentative_track(const TrackType & track) -> void
+  auto add_tentative_track(const Track & track) -> void
   {
     const auto uuid = get_uuid(track);
+
+    if (tracks_.count(uuid) != 0) {
+      throw std::logic_error("track '" + uuid.value() + "' already exists");
+    }
+
     tracks_[uuid] = track;
-    track_statuses_[uuid] = TrackStatus::kTentative;
+    statuses_[uuid] = TrackStatus::kTentative;
+    occurrences_[uuid] = 1;
   }
 
-  auto get_tentative_tracks() const -> std::vector<TrackType>
+  auto get_tentative_tracks() const -> std::vector<Track>
   {
-    std::vector<TrackType> tracks;
+    std::vector<Track> tracks;
 
     for (const auto & [uuid, track] : tracks_) {
-      if (track_statuses_.at(uuid) == TrackStatus::kTentative) {
+      if (statuses_.at(uuid) == TrackStatus::kTentative) {
         tracks.emplace_back(track);
       }
     }
@@ -114,12 +101,12 @@ public:
     return tracks;
   }
 
-  auto get_confirmed_tracks() const -> std::vector<TrackType>
+  auto get_confirmed_tracks() const -> std::vector<Track>
   {
-    std::vector<TrackType> tracks;
+    std::vector<Track> tracks;
 
     for (const auto & [uuid, track] : tracks_) {
-      if (track_statuses_.at(uuid) == TrackStatus::kConfirmed) {
+      if (statuses_.at(uuid) == TrackStatus::kConfirmed) {
         tracks.emplace_back(track);
       }
     }
@@ -127,9 +114,9 @@ public:
     return tracks;
   }
 
-  auto get_all_tracks() const -> std::vector<TrackType>
+  auto get_all_tracks() const -> std::vector<Track>
   {
-    std::vector<TrackType> tracks;
+    std::vector<Track> tracks;
 
     for (const auto & [uuid, track] : tracks_) {
       tracks.emplace_back(track);
@@ -139,9 +126,11 @@ public:
   }
 
 private:
-  ManagementPolicy management_policy_;
-  std::unordered_map<Uuid, TrackType> tracks_;
-  std::unordered_map<Uuid, TrackStatus> track_statuses_;
+  PromotionThreshold promotion_threshold_;
+  RemovalThreshold removal_threshold_;
+  std::unordered_map<Uuid, Track> tracks_;
+  std::unordered_map<Uuid, TrackStatus> statuses_;
+  std::unordered_map<Uuid, std::size_t> occurrences_;
 };
 
 }  // namespace cooperative_perception

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(test_cooperative_perceptionExecutable
   test_gating.cpp
   test_fusing.cpp
   test_json_parsing.cpp
+  test_track_management.cpp
 )
 
 target_include_directories(test_cooperative_perceptionExecutable

--- a/test/test_track_management.cpp
+++ b/test/test_track_management.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Leidos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <units.h>
+
+#include <cooperative_perception/ctrv_model.hpp>
+#include <cooperative_perception/track_management.hpp>
+#include <cooperative_perception/uuid.hpp>
+
+namespace cp = cooperative_perception;
+
+TEST(TestTrackManagement, Simple)
+{
+  cp::FixedThresholdTrackManager<cp::CtrvTrack> track_manager{
+    cp::PromotionThreshold{3}, cp::RemovalThreshold{1}};
+
+  cp::CtrvTrack track;
+  track.uuid = cp::Uuid{"test_track"};
+
+  cp::AssociationMap association_map;
+  association_map[cp::Uuid{"test_track"}].push_back(cp::Uuid{"test_detection"});
+
+  track_manager.add_tentative_track(track);
+
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 1U);
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
+
+  track_manager.update_track_lists(association_map);
+
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 1U);
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
+
+  track_manager.update_track_lists(association_map);
+
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 1U);
+  EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
+
+  track_manager.update_track_lists(cp::AssociationMap{});
+
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 1U);
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
+
+  track_manager.update_track_lists(cp::AssociationMap{});
+  track_manager.update_track_lists(cp::AssociationMap{});
+
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_all_tracks()), 0U);
+}


### PR DESCRIPTION
# PR Details
## Description

This PR replaces the generic `TrackManager` class with one that only uses a fixed-threshold management policy. The original generic class was unnecessarily complex for our use-case, especially since we were only using the fixed-threshold management policy.

## Related GitHub Issue

Closes #86 

## Related Jira Key

Closes [CDAR-424](https://usdot-carma.atlassian.net/browse/CDAR-424)

## Motivation and Context

This change significantly simplifies the codebase without affecting performance.

## How Has This Been Tested?

## Types of changes

- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-424]: https://usdot-carma.atlassian.net/browse/CDAR-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ