### PR TITLE
Add clustering support

### DIFF
--- a/docs/clustering/cluster/add_detection.md
+++ b/docs/clustering/cluster/add_detection.md
@@ -1,0 +1,15 @@
+# `multiple_object_tracking::Cluster<Detection>::add_detection`
+
+```cpp
+auto add_detection(const Detection & detection);
+```
+
+Adds a detection to the cluster.
+
+## Parameters
+
+- `detection` - the detection to be added to the cluster
+
+## Return value
+
+(none)

--- a/docs/clustering/cluster/clear.md
+++ b/docs/clustering/cluster/clear.md
@@ -1,0 +1,15 @@
+# `multiple_object_tracking::Cluster<Detection>::clear`
+
+```cpp
+auto clear() noexcept -> void;
+```
+
+Removes all detections from the cluster.
+
+## Parameters
+
+(none)
+
+## Return value
+
+(none)

--- a/docs/clustering/cluster/get_centroid.md
+++ b/docs/clustering/cluster/get_centroid.md
@@ -5,7 +5,8 @@
 auto get_centroid() const -> Point;
 ```
 
-Returns the cluster's geometric center. If the cluster is empty, an exception of type `std::runtime_error` is thrown.
+Returns the cluster's _centroid_: a point equal to the mean of a cluster's contained members. If the cluster is empty,
+an exception of type `std::runtime_error` is thrown.
 
 ## Parameters
 
@@ -13,7 +14,7 @@ Returns the cluster's geometric center. If the cluster is empty, an exception of
 
 ## Return value
 
-The cluster's geometric center.
+The cluster's centroid.
 
 ## Exceptions
 

--- a/docs/clustering/cluster/get_centroid.md
+++ b/docs/clustering/cluster/get_centroid.md
@@ -1,0 +1,20 @@
+# `multiple_object_tracking::Cluster<Detection>::get_centroid`
+
+```cpp
+[[nodiscard]]
+auto get_centroid() const -> Point;
+```
+
+Returns the cluster's geometric center. If the cluster is empty, an exception of type `std::runtime_error` is thrown.
+
+## Parameters
+
+(none)
+
+## Return value
+
+The cluster's geometric center.
+
+## Exceptions
+
+`std::runtime_error` if cluster is empty.

--- a/docs/clustering/cluster/get_detections.md
+++ b/docs/clustering/cluster/get_detections.md
@@ -1,0 +1,16 @@
+# `multiple_object_tracking::Cluster<Detection>::get_detections`
+
+```cpp
+[[nodiscard]]
+auto get_detections() const noexcept -> const std::unordered_map<Uuid, Detection> &
+```
+
+Returns a reference to the cluster's contained detections.
+
+## Parameters
+
+(none)
+
+## Return value
+
+Reference to the cluster's contained detections.

--- a/docs/clustering/cluster/index.md
+++ b/docs/clustering/cluster/index.md
@@ -1,0 +1,54 @@
+# `multiple_object_tracking::Cluster`
+
+Defined in header `<multpile_object_tracking/clustering.hpp>`
+
+```cpp
+template <
+    typename Detection
+> class Cluster;
+```
+
+This class contains a sequence of detections that are within a specific Euclidean distance of each other.
+
+## Member functions
+
+|                                       |                          |
+| ------------------------------------- | ------------------------ |
+| (constructor) _(implicitly declared)_ | constructs the `Cluster` |
+| (destructor) _(implicitly declared)_  | destructs the `Cluster`  |
+
+### Observers
+
+|                                    |                                                             |
+| ---------------------------------- | ----------------------------------------------------------- |
+| [`get_centroid`][get_centroid_doc] | returns a point representing the cluster's geometric center |
+
+[get_centroid_doc]: get_centroid.md
+
+### Accessors
+
+|                                        |                                                    |
+| -------------------------------------- | -------------------------------------------------- |
+| [`get_detections`][get_detections_doc] | access the detections contained within the cluster |
+
+[get_detections_doc]: get_detections.md
+
+### Capacity
+
+|                            |                                     |
+| -------------------------- | ----------------------------------- |
+| [`is_empty`][is_empty_doc] | checks whether the cluster is empty |
+
+[is_empty_doc]: is_empty.md
+
+### Modifiers
+
+|                                            |                                      |
+| ------------------------------------------ | ------------------------------------ |
+| [`clear`][clear_doc]                       | clears the cluster's contents        |
+| [`add_detection`][add_detection_doc]       | adds a detection to the cluster      |
+| [`remove_detection`][remove_detection_doc] | removes a detection from the cluster |
+
+[clear_doc]: clear.md
+[add_detection_doc]: add_detection.md
+[remove_detection_doc]: remove_detection.md

--- a/docs/clustering/cluster/is_empty.md
+++ b/docs/clustering/cluster/is_empty.md
@@ -1,0 +1,16 @@
+# `multiple_object_tracking::Cluster<Detection>::is_empty`
+
+```cpp
+[[nodiscard]]
+auto is_empty() const noexcept -> bool;
+```
+
+Checks if the cluster is empty.
+
+## Parameters
+
+(none)
+
+## Return value
+
+`true` is the cluster is empty; `false` otherwise.

--- a/docs/clustering/cluster/remove_detection.md
+++ b/docs/clustering/cluster/remove_detection.md
@@ -1,0 +1,15 @@
+# `multiple_object_tracking::Cluster<Detection>::remove_detection`
+
+```cpp
+auto remove_detection(const Uuid & uuid);
+```
+
+Removes a detection with the specified identifier from the cluster.
+
+## Parameters
+
+- `uuid` - universally-unique identifier (UUID) of the detection to be removed
+
+## Return value
+
+(none)

--- a/docs/clustering/cluster_detections.md
+++ b/docs/clustering/cluster_detections.md
@@ -1,0 +1,29 @@
+# `multiple_object_tracking::cluster_detections`
+
+Defined in `<multiple_object_tracking/clustering.hpp>`
+
+```cpp
+template <typename Detection>
+[[nodiscard]]
+auto cluster_detections(
+    std::vector<Detection> detections,
+    double distance_threshold
+) -> std::vector<Cluster<Detection>>;
+```
+
+Group the `detections` into clusters based on their relative Euclidean distances. All detections whose Euclidean
+distances are within `distance_threshold` will be grouped into the same cluster. Detections that could belong to
+multiple clusters will non-deterministaclly be assigned to a single one.
+
+## Template parameters
+
+- `Detection` - the type of detections being clustered
+
+## Parameters
+
+- `detections` - the detections to be grouped into clusters
+- `distance_threshold` - the Euclidean distance below which two detections will be considered part of the same cluster
+
+## Return value
+
+The clusters generated from the provided `detections`.

--- a/docs/clustering/point/index.md
+++ b/docs/clustering/point/index.md
@@ -1,0 +1,28 @@
+# `multiple_object_tracking::Point`
+
+Defined in header `<multiple_object_tracking/clustering.hpp>`
+
+```cpp
+struct Point;
+```
+
+This class represents the geometric center of a cluster. It is a sub-vector of `multiple_object_tracking::CtrvState`
+and `multiple_object_tracking::CtraState` containing the common vector elements.
+
+## Data members
+
+| Name         | Type                                            | Description                                          |
+| ------------ | ----------------------------------------------- | ---------------------------------------------------- |
+| `position_x` | `units::length::meter_t`                        | _x_-position                                         |
+| `position_y` | `units::length::meter_t`                        | _y_-position                                         |
+| `velocity`   | `units::velocity::meters_per_second_t`          | signed speed in direction of yaw                     |
+| `yaw`        | `multiple_object_tracking::Angle`               | angle from the coordinate frame's _x_-axis           |
+| `yaw_rate`   | `units::angular_velocity::radians_per_second_t` | angular signed speed (counter-clockwise is positive) |
+
+## Non-member functions
+
+|                                    |                          |
+| ---------------------------------- | ------------------------ |
+| [`operator/`][operator_divide_doc] | performs scalar division |
+
+[operator_divide_doc]: operator_divide.md

--- a/docs/clustering/point/index.md
+++ b/docs/clustering/point/index.md
@@ -6,8 +6,9 @@ Defined in header `<multiple_object_tracking/clustering.hpp>`
 struct Point;
 ```
 
-This class represents the geometric center of a cluster. It is a sub-vector of `multiple_object_tracking::CtrvState`
-and `multiple_object_tracking::CtraState` containing the common vector elements.
+This class represents a cluster's _centroid_: a point equal to the mean of a cluster's contained members. It is a
+sub-vector of `multiple_object_tracking::CtrvState` and `multiple_object_tracking::CtraState` containing the common
+(mathematical) vector elements.
 
 ## Data members
 

--- a/docs/clustering/point/operator_divide.md
+++ b/docs/clustering/point/operator_divide.md
@@ -1,0 +1,17 @@
+# `multiple_object_tracking::operator/`
+
+```cpp
+[[nodiscard]]
+inline auto operator/(Point point, double scalar) -> Point;
+```
+
+Performs scalar division.
+
+## Parameters
+
+- `point` - dividend
+- `scalar` - divisor
+
+## Return value
+
+A point whose value is equal to the scalar quotient.

--- a/docs/main.md
+++ b/docs/main.md
@@ -1,5 +1,27 @@
 # Multiple object tracking library
 
+## Clustering
+
+### [`multiple_object_tracking::Cluster`][cluster_doc]
+
+This class contains a sequence of detections that are within a specific Euclidean distance of each other.
+
+[cluster_doc]: clustering/cluster/index.md
+
+### [`multiple_object_tracking::Point`][point_doc]
+
+This class represents the geometric center of a cluster. It is a sub-vector of `multiple_object_tracking::CtrvState` and `multiple_object_tracking::CtraState` containing the common vector elements.
+
+[point_doc]: clustering/point/index.md
+
+### Clustering operations
+
+|                                                |                                                                                            |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [`cluster_detections`][cluster_detections_doc] | group a collection of detections into clusters based on their relative Euclidean distances |
+
+[cluster_detections_doc]: clustering/cluster_detections.md
+
 ## Track maintenance
 
 ### [`multiple_object_tracking::FixedThresholdTrackManager`][fixed_threshold_track_manager_doc]
@@ -9,4 +31,3 @@ stores a list of `multiple_object_tracking::Track`s and manages their statuses (
 _confirmed_) using a fixed-threshold policy.
 
 [fixed_threshold_track_manager_doc]: track_management/fixed_threshold_track_manager/main.md
-

--- a/include/cooperative_perception/clustering.hpp
+++ b/include/cooperative_perception/clustering.hpp
@@ -24,7 +24,7 @@ struct Point
   units::angular_velocity::radians_per_second_t yaw_rate{0};
 };
 
-inline auto operator/(Point point, double scalar) -> Point
+[[nodiscard]] inline auto operator/(Point point, double scalar) -> Point
 {
   point.position_x /= scalar;
   point.position_y /= scalar;

--- a/include/cooperative_perception/clustering.hpp
+++ b/include/cooperative_perception/clustering.hpp
@@ -196,7 +196,7 @@ auto make_point(const std::variant<Alternatives...> & detection) -> Point
 }  // namespace detail
 
 template <typename Detection>
-auto cluster_detections(std::vector<Detection> detections, double distance_threshold)
+[[nodiscard]] auto cluster_detections(std::vector<Detection> detections, double distance_threshold)
   -> std::vector<Cluster<Detection>>
 {
   std::vector<Cluster<Detection>> clusters;

--- a/include/cooperative_perception/clustering.hpp
+++ b/include/cooperative_perception/clustering.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Leidos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef COOPERATIVE_PERCEPTION_CLUSTERING_HPP
 #define COOPERATIVE_PERCEPTION_CLUSTERING_HPP
 

--- a/include/cooperative_perception/clustering.hpp
+++ b/include/cooperative_perception/clustering.hpp
@@ -101,7 +101,7 @@ template <typename Detection>
 class Cluster
 {
 public:
-  auto is_empty() const noexcept -> bool { return std::size(detections_) == 0; }
+  [[nodiscard]] auto is_empty() const noexcept -> bool { return std::size(detections_) == 0; }
   auto clear() noexcept -> void { detections_.clear(); }
 
   auto add_detection(const Detection & detection)
@@ -116,12 +116,12 @@ public:
     detections_.erase(uuid);
   }
 
-  auto get_detections() const noexcept -> const std::unordered_map<Uuid, Detection> &
+  [[nodiscard]] auto get_detections() const noexcept -> const std::unordered_map<Uuid, Detection> &
   {
     return detections_;
   }
 
-  auto get_centroid() const -> Point
+  [[nodiscard]] auto get_centroid() const -> Point
   {
     if (detections_.empty()) {
       throw std::runtime_error("cluster is empty");

--- a/include/cooperative_perception/clustering.hpp
+++ b/include/cooperative_perception/clustering.hpp
@@ -1,0 +1,340 @@
+#ifndef COOPERATIVE_PERCEPTION_CLUSTERING_HPP
+#define COOPERATIVE_PERCEPTION_CLUSTERING_HPP
+
+#include <units.h>
+
+#include <random>
+#include <variant>
+#include <vector>
+
+#include "cooperative_perception/angle.hpp"
+#include "cooperative_perception/ctra_model.hpp"
+#include "cooperative_perception/ctrv_model.hpp"
+#include "cooperative_perception/uuid.hpp"
+#include "cooperative_perception/visitor.hpp"
+
+namespace cooperative_perception
+{
+struct Point
+{
+  units::length::meter_t position_x{0};
+  units::length::meter_t position_y{0};
+  units::velocity::meters_per_second_t velocity{0};
+  Angle yaw{units::angle::radian_t{0}};
+  units::angular_velocity::radians_per_second_t yaw_rate{0};
+};
+
+inline auto operator/(Point point, double scalar) -> Point
+{
+  point.position_x /= scalar;
+  point.position_y /= scalar;
+  point.velocity /= scalar;
+  point.yaw /= scalar;
+  point.yaw_rate /= scalar;
+
+  return point;
+}
+
+namespace detail
+{
+struct element_wise_add_fn
+{
+  template <typename Detection>
+  auto operator()(Point point, const Detection & detection) const -> Point
+  {
+    point.position_x += detection.state.position_x;
+    point.position_y += detection.state.position_y;
+    point.velocity += detection.state.velocity;
+    point.yaw += detection.state.yaw;
+    point.yaw_rate += detection.state.yaw_rate;
+
+    return point;
+  }
+
+  template <typename... Alternatives>
+  auto operator()(Point point, const std::variant<Alternatives...> & detection) const -> Point
+  {
+    const Visitor visitor{
+      [this](const Point & p, const CtrvDetection & d) { return this->operator()(p, d); },
+      [this](const Point & p, const CtraDetection & d) { return this->operator()(p, d); },
+      [this](const auto &, const auto &) { throw std::runtime_error("cannot add vector types"); }};
+
+    return std::visit(visitor, std::variant<Point>{point}, detection);
+  }
+};
+
+inline constexpr element_wise_add_fn element_wise_add{};
+
+struct element_wise_subtract_fn
+{
+  template <typename Detection>
+  auto operator()(Point point, const Detection & detection) const -> Point
+  {
+    point.position_x -= detection.state.position_x;
+    point.position_y -= detection.state.position_y;
+    point.velocity -= detection.state.velocity;
+    point.yaw -= detection.state.yaw;
+    point.yaw_rate -= detection.state.yaw_rate;
+
+    return point;
+  }
+
+  template <typename... Alternatives>
+  auto operator()(Point point, const std::variant<Alternatives...> & detection) const -> Point
+  {
+    const Visitor visitor{
+      [this](const Point & p, const CtrvDetection & d) { return this->operator()(p, d); },
+      [this](const Point & p, const CtraDetection & d) { return this->operator()(p, d); },
+      [this](const auto &, const auto &) {
+        throw std::runtime_error("cannot subtract vector types");
+      }};
+
+    return std::visit(visitor, std::variant<Point>{point}, detection);
+  }
+};
+
+inline constexpr element_wise_subtract_fn element_wise_subtract{};
+
+}  // namespace detail
+
+template <typename Detection>
+class Cluster
+{
+public:
+  auto is_empty() const noexcept -> bool { return std::size(detections_) == 0; }
+  auto clear() noexcept -> void { detections_.clear(); }
+
+  auto add_detection(const Detection & detection)
+  {
+    state_sum_ = detail::element_wise_add(state_sum_, detection);
+    detections_.emplace(get_uuid(detection), detection);
+  }
+
+  auto remove_detection(const Uuid & uuid)
+  {
+    state_sum_ = detail::element_wise_subtract(state_sum_, detections_.at(uuid));
+    detections_.erase(uuid);
+  }
+
+  auto get_detections() const noexcept -> const std::unordered_map<Uuid, Detection> &
+  {
+    return detections_;
+  }
+
+  auto get_centroid() const -> Point
+  {
+    if (detections_.empty()) {
+      throw std::runtime_error("cluster is empty");
+    }
+
+    return state_sum_ / std::size(detections_);
+  }
+
+  Point state_sum_;
+  std::unordered_map<Uuid, Detection> detections_;
+};
+
+namespace detail
+{
+struct squared_euclidean_distance_fn
+{
+  template <typename Detection>
+  auto operator()(const Point & point, const Detection & detection) const -> double
+  {
+    double sum{0};
+
+    sum += std::pow(remove_units(point.position_x - detection.state.position_x), 2);
+    sum += std::pow(remove_units(point.position_y - detection.state.position_y), 2);
+    sum += std::pow(remove_units(point.velocity - detection.state.velocity), 2);
+    sum += std::pow(remove_units(point.yaw.get_angle() - detection.state.yaw.get_angle()), 2);
+    sum += std::pow(remove_units(point.yaw_rate - detection.state.yaw_rate), 2);
+
+    return sum;
+  }
+
+  template <typename... Alternatives>
+  auto operator()(Point point, const std::variant<Alternatives...> & detection) const -> double
+  {
+    const Visitor visitor{
+      [this](const Point & p, const CtrvDetection & d) { return this->operator()(p, d); },
+      [this](const Point & p, const CtraDetection & d) { return this->operator()(p, d); },
+      [this](const auto &, const auto &) { std::numeric_limits<double>::max(); }};
+
+    return std::visit(visitor, std::variant<Point>{point}, detection);
+  }
+};
+
+inline constexpr squared_euclidean_distance_fn squared_euclidean_distance{};
+
+template <typename Detection>
+auto get_closest_mean_index(const std::vector<Point> & means, const Detection & detection)
+  -> std::size_t
+{
+  std::size_t best_index{0U};
+  double best_distance{std::numeric_limits<double>::max()};
+
+  for (auto i{0U}; i < std::size(means); ++i) {
+    const auto dist{squared_euclidean_distance(means.at(i), detection)};
+
+    if (dist < best_distance) {
+      best_distance = dist;
+      best_index = i;
+    }
+  }
+
+  return best_index;
+}
+
+auto initialize_means(std::size_t num_means)
+{
+  std::random_device device;
+  std::default_random_engine engine{device()};
+  std::uniform_real_distribution distribution;
+
+  std::vector<Point> points;
+  for (auto i{0U}; i < num_means; ++i) {
+    Point point;
+
+    point.position_x = units::length::meter_t{distribution(engine)};
+    point.position_y = units::length::meter_t{distribution(engine)};
+    point.velocity = units::velocity::meters_per_second_t{distribution(engine)};
+    point.yaw.set_angle(units::angle::radian_t{distribution(engine)});
+    point.yaw_rate = units::angular_velocity::radians_per_second_t{distribution(engine)};
+
+    points.push_back(std::move(point));
+  }
+
+  return points;
+}
+
+template <typename Detection>
+auto initialize_means(std::size_t num_means, const std::vector<Detection> & detections)
+{
+  std::vector<Point> means(num_means);
+  std::vector<Cluster<Detection>> clusters(num_means);
+
+  for (auto c{0U}; c < std::size(clusters); ++c) {
+    clusters.at(c).add_detection(detections.at(c));
+  }
+
+  for (auto i{0U}; i < std::size(clusters); ++i) {
+    means.at(i) = clusters.at(i).get_centroid();
+    clusters.at(i).clear();
+  }
+
+  return means;
+}
+
+template <typename Detection>
+auto get_cluster_assignments(const std::vector<Cluster<Detection>> & clusters)
+{
+  std::vector<std::vector<Uuid>> assignments;
+
+  for (const auto & cluster : clusters) {
+    std::vector<Uuid> uuids;
+    for (const auto & [uuid, detection] : cluster.get_detections()) {
+      uuids.push_back(uuid);
+    }
+
+    assignments.push_back(std::move(uuids));
+  }
+
+  return assignments;
+}
+
+template <typename Detection>
+auto make_point(const Detection & detection) -> Point
+{
+  return Point{
+    detection.state.position_x, detection.state.position_y, detection.state.velocity,
+    detection.state.yaw, detection.state.yaw_rate};
+}
+
+template <typename... Alternatives>
+auto make_point(const std::variant<Alternatives...> & detection) -> Point
+{
+  const Visitor visitor{
+    [](const CtrvDetection & detection) {
+      return Point{
+        detection.state.position_x, detection.state.position_y, detection.state.velocity,
+        detection.state.yaw, detection.state.yaw_rate};
+    },
+    [](const CtraDetection & detection) {
+      return Point{
+        detection.state.position_x, detection.state.position_y, detection.state.velocity,
+        detection.state.yaw, detection.state.yaw_rate};
+    },
+    [](const auto &) { throw std::runtime_error("cannot make point from detection"); }};
+
+  return std::visit(visitor, detection);
+}
+
+}  // namespace detail
+
+template <typename Detection>
+auto cluster_detections(std::vector<Detection> detections, double distance_threshold)
+  -> std::vector<Cluster<Detection>>
+{
+  std::vector<Cluster<Detection>> clusters;
+
+  while (!detections.empty()) {
+    Cluster<Detection> cluster;
+
+    const auto origin_detection{detections.back()};
+    const auto origin_point{detail::make_point(origin_detection)};
+
+    cluster.add_detection(origin_detection);
+    detections.pop_back();
+
+    for (auto it{std::begin(detections)}; it != std::end(detections);) {
+      if (detail::squared_euclidean_distance(origin_point, *it) < distance_threshold) {
+        cluster.add_detection(*it);
+        detections.erase(it);
+      } else {
+        ++it;
+      }
+    }
+
+    clusters.push_back(std::move(cluster));
+  }
+
+  return clusters;
+}
+
+// template <typename Detection>
+// auto cluster_detections(const std::vector<Detection> & detections, std::size_t num_clusters)
+//   -> std::vector<Cluster<Detection>>
+// {
+//   if (num_clusters > std::size(detections)) {
+//     throw std::logic_error(
+//       "number of clusters ('" + std::to_string(num_clusters) +
+//       "') must be less than or equal to number of detections ('" +
+//       std::to_string(std::size(detections)) + "')");
+//   }
+
+//   std::vector<Cluster<Detection>> clusters(num_clusters);
+//   auto means{detail::initialize_means(num_clusters, detections)};
+//   auto previous_assignments{detail::get_cluster_assignments(clusters)};
+
+//   do {
+//     previous_assignments = detail::get_cluster_assignments(clusters);
+
+//     for (auto & cluster : clusters) {
+//       cluster.clear();
+//     }
+
+//     for (const auto & detection : detections) {
+//       clusters.at(detail::get_closest_mean_index(means, detection)).add_detection(detection);
+//     }
+
+//     for (auto i{0U}; i < std::size(clusters); ++i) {
+//       means.at(i) = clusters.at(i).get_centroid();
+//     }
+//   } while (detail::get_cluster_assignments(clusters) != previous_assignments);
+
+//   return clusters;
+// }
+
+}  // namespace cooperative_perception
+
+#endif  // COOPERATIVE_PERCEPTION_CLUSTERING_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(test_cooperative_perceptionExecutable
   test_gating.cpp
   test_fusing.cpp
   test_json_parsing.cpp
+  test_clustering.cpp
   test_track_management.cpp
 )
 

--- a/test/data/test_clustering_disjoint.json
+++ b/test/data/test_clustering_disjoint.json
@@ -1,0 +1,36 @@
+{
+  "detections": [
+    {
+      "motion_model": "ctrv",
+      "timestamp_sec": 0.0,
+      "state": {
+        "position_x_m": 5.0,
+        "position_y_m": 5.0,
+        "velocity_mps": 0.0,
+        "yaw_rad": 0.0,
+        "yaw_rate_rad_per_s": 0.0
+      },
+      "covariance": [
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+      ],
+      "uuid": "detection1"
+    },
+    {
+      "motion_model": "ctrv",
+      "timestamp_sec": 0.0,
+      "state": {
+        "position_x_m": 6.0,
+        "position_y_m": 5.0,
+        "velocity_mps": 0.0,
+        "yaw_rad": 0.0,
+        "yaw_rate_rad_per_s": 0.0
+      },
+      "covariance": [
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+      ],
+      "uuid": "detection2"
+    }
+  ]
+}

--- a/test/data/test_clustering_overlapping.json
+++ b/test/data/test_clustering_overlapping.json
@@ -1,0 +1,36 @@
+{
+  "detections": [
+    {
+      "motion_model": "ctrv",
+      "timestamp_sec": 0.0,
+      "state": {
+        "position_x_m": 5.0,
+        "position_y_m": 5.0,
+        "velocity_mps": 0.0,
+        "yaw_rad": 0.0,
+        "yaw_rate_rad_per_s": 0.0
+      },
+      "covariance": [
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+      ],
+      "uuid": "detection1"
+    },
+    {
+      "motion_model": "ctrv",
+      "timestamp_sec": 0.0,
+      "state": {
+        "position_x_m": 5.0,
+        "position_y_m": 5.0,
+        "velocity_mps": 0.0,
+        "yaw_rad": 0.0,
+        "yaw_rate_rad_per_s": 0.0
+      },
+      "covariance": [
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+      ],
+      "uuid": "detection2"
+    }
+  ]
+}

--- a/test/test_clustering.cpp
+++ b/test/test_clustering.cpp
@@ -34,6 +34,7 @@ TEST(TestCluser, Simple)
   EXPECT_EQ(centroid.yaw.get_angle(), units::angle::radian_t{0.0});
   EXPECT_EQ(centroid.yaw_rate, units::angular_velocity::radians_per_second_t{0.0});
 
+  detection.state.position_x = units::length::meter_t{3.0};
   detection.uuid = cp::Uuid{"detection2"};
   cluster.add_detection(detection);
   centroid = cluster.get_centroid();
@@ -45,6 +46,7 @@ TEST(TestCluser, Simple)
   EXPECT_EQ(centroid.yaw.get_angle(), units::angle::radian_t{0.0});
   EXPECT_EQ(centroid.yaw_rate, units::angular_velocity::radians_per_second_t{0.0});
 
+  detection.state.position_x = units::length::meter_t{5.0};
   detection.uuid = cp::Uuid{"detection3"};
   cluster.add_detection(detection);
   centroid = cluster.get_centroid();

--- a/test/test_clustering.cpp
+++ b/test/test_clustering.cpp
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+
+#include <cooperative_perception/clustering.hpp>
+#include <cooperative_perception/ctra_model.hpp>
+#include <cooperative_perception/ctrv_model.hpp>
+#include <cooperative_perception/json_parsing.hpp>
+#include <fstream>
+
+namespace cp = cooperative_perception;
+
+TEST(TestCluster, Empty)
+{
+  cp::Cluster<cp::CtraDetection> cluster;
+
+  ASSERT_TRUE(cluster.is_empty());
+  EXPECT_THROW((void)cluster.get_centroid(), std::runtime_error);
+}
+
+TEST(TestCluser, Simple)
+{
+  cp::Cluster<cp::CtrvDetection> cluster;
+
+  cp::CtrvDetection detection;
+  detection.state.position_x = units::length::meter_t{1.0};
+  detection.uuid = cp::Uuid{"detection1"};
+
+  cluster.add_detection(detection);
+  auto centroid{cluster.get_centroid()};
+
+  // This will use the operator== overload, which for units library is almost-equality
+  EXPECT_EQ(centroid.position_x, units::length::meter_t{1.0});
+  EXPECT_EQ(centroid.position_y, units::length::meter_t{0.0});
+  EXPECT_EQ(centroid.velocity, units::velocity::meters_per_second_t{0.0});
+  EXPECT_EQ(centroid.yaw.get_angle(), units::angle::radian_t{0.0});
+  EXPECT_EQ(centroid.yaw_rate, units::angular_velocity::radians_per_second_t{0.0});
+
+  detection.uuid = cp::Uuid{"detection2"};
+  cluster.add_detection(detection);
+  centroid = cluster.get_centroid();
+
+  // This will use the operator== overload, which for units library is almost-equality
+  EXPECT_EQ(centroid.position_x, units::length::meter_t{2.0});
+  EXPECT_EQ(centroid.position_y, units::length::meter_t{0.0});
+  EXPECT_EQ(centroid.velocity, units::velocity::meters_per_second_t{0.0});
+  EXPECT_EQ(centroid.yaw.get_angle(), units::angle::radian_t{0.0});
+  EXPECT_EQ(centroid.yaw_rate, units::angular_velocity::radians_per_second_t{0.0});
+
+  detection.uuid = cp::Uuid{"detection3"};
+  cluster.add_detection(detection);
+  centroid = cluster.get_centroid();
+
+  // This will use the operator== overload, which for units library is almost-equality
+  EXPECT_EQ(centroid.position_x, units::length::meter_t{3.0});
+  EXPECT_EQ(centroid.position_y, units::length::meter_t{0.0});
+  EXPECT_EQ(centroid.velocity, units::velocity::meters_per_second_t{0.0});
+  EXPECT_EQ(centroid.yaw.get_angle(), units::angle::radian_t{0.0});
+  EXPECT_EQ(centroid.yaw_rate, units::angular_velocity::radians_per_second_t{0.0});
+
+  cluster.remove_detection(cp::Uuid{"detection3"});
+  centroid = cluster.get_centroid();
+
+  // This will use the operator== overload, which for units library is almost-equality
+  EXPECT_EQ(centroid.position_x, units::length::meter_t{2.0});
+  EXPECT_EQ(centroid.position_y, units::length::meter_t{0.0});
+  EXPECT_EQ(centroid.velocity, units::velocity::meters_per_second_t{0.0});
+  EXPECT_EQ(centroid.yaw.get_angle(), units::angle::radian_t{0.0});
+  EXPECT_EQ(centroid.yaw_rate, units::angular_velocity::radians_per_second_t{0.0});
+}
+
+TEST(TestClustering, Disjoint)
+{
+  std::ifstream detections_file{"data/test_clustering_disjoint.json"};
+  ASSERT_TRUE(detections_file);
+
+  const auto detections{cp::detections_from_json_file<cp::CtrvDetection>(detections_file)};
+
+  EXPECT_EQ(std::size(cp::cluster_detections(detections, 1.0)), 2U);
+  EXPECT_EQ(std::size(cp::cluster_detections(detections, 3.0)), 1U);
+}
+
+TEST(TestClustering, Overlapping)
+{
+  std::ifstream detections_file{"data/test_clustering_overlapping.json"};
+  ASSERT_TRUE(detections_file);
+
+  const auto detections{cp::detections_from_json_file<cp::CtrvDetection>(detections_file)};
+
+  EXPECT_EQ(std::size(cp::cluster_detections(detections, 1.0)), 1U);
+  EXPECT_EQ(std::size(cp::cluster_detections(detections, 3.0)), 1U);
+}


### PR DESCRIPTION
# PR Details
## Description

This PR adds support for clustering detections based on their Euclidean distances. It introduces the `Cluster` class and the `cluster_detections` function. There are some additional detail functions, but they are not part of the public interface.

## Related GitHub Issue

Closes #87 

## Related Jira Key

Closes [CDAR-423](https://usdot-carma.atlassian.net/browse/CDAR-423)

## Motivation and Context

When there are multiple detections corresponding to the same non-existent track, we need to choose a single representation. Otherwise, we will have duplicated tracks, which can cause association issues in the next iteration. By clustering detections, we can better choose which single detection (or aggregation) will represent the cluster.

## How Has This Been Tested?

Added unit tests.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-423]: https://usdot-carma.atlassian.net/browse/CDAR-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ