### PR TITLE
Add support for more detections than tracks

### DIFF
--- a/include/cooperative_perception/track_matching.hpp
+++ b/include/cooperative_perception/track_matching.hpp
@@ -244,7 +244,7 @@ inline auto gnn_associator(const ScoreMap & scores) -> AssociationMap
 
   // dlib requires square matrices, so we will padd with phantom tracks
   if (cost_matrix.nr() != cost_matrix.nc()) {
-    const auto cost_matrix_original{cost_matrix};
+    const auto cost_matrix_original{dlib::tmp(cost_matrix)};
     cost_matrix.set_size(cost_matrix.nc(), cost_matrix.nc());
 
     for (auto row{0U}; row < cost_matrix_original.nr(); ++row) {

--- a/include/cooperative_perception/track_matching.hpp
+++ b/include/cooperative_perception/track_matching.hpp
@@ -242,7 +242,7 @@ inline auto gnn_associator(const ScoreMap & scores) -> AssociationMap
   // Generate the cost matrix
   auto cost_matrix = cost_matrix_from_score_matrix(score_matrix);
 
-  // dlib requires square matrices, so we will padd with phantom tracks
+  // dlib requires square matrices, so we will pad with phantom tracks
   if (cost_matrix.nr() != cost_matrix.nc()) {
     const auto cost_matrix_original{dlib::tmp(cost_matrix)};
     cost_matrix.set_size(cost_matrix.nc(), cost_matrix.nc());

--- a/test/test_track_matching.cpp
+++ b/test/test_track_matching.cpp
@@ -174,11 +174,11 @@ TEST(TestTrackMatching, GnnAssociatorMoreDetectionsThanTracks)
     EXPECT_EQ(std::size(expected_detection_uuids), std::size(result_detection_uuids));
 
     for (const auto & expected_detection_uuid : expected_detection_uuids) {
-      const auto it{std::find(
-        std::cbegin(result_detection_uuids), std::cend(result_detection_uuids),
-        expected_detection_uuid)};
-
-      EXPECT_NE(it, std::cend(result_detection_uuids));
+      EXPECT_NE(
+        std::find(
+          std::cbegin(result_detection_uuids), std::cend(result_detection_uuids),
+          expected_detection_uuid),
+        std::cend(result_detection_uuids));
     }
   }
 }


### PR DESCRIPTION
# PR Details
## Description

This PR modifies the association implementations to allow for more detections than tracks. Previously, it was implicitly assumed that each detection would have at least one possible track to associate with. However, this is not always the case. When we encounter scenarios with more detections than tracks, the current implementation fails with an indexing error.

The revised implementation pads the underlying cost matrix with phantom tracks until there is a possible (not necessarily optimal) one-to-one association. After the association step, the phantom associations are discarded.

## Related GitHub Issue

Closes #93 

## Related Jira Key

Closes [CDAR-439](https://usdot-carma.atlassian.net/browse/CDAR-439)

## Motivation and Context

The previous implementation would fail when there are more detections than tracks.

## How Has This Been Tested?


## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-439]: https://usdot-carma.atlassian.net/browse/CDAR-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ