### PR TITLE
Fix detection erasing in cluster_detections

### DIFF
--- a/include/cooperative_perception/clustering.hpp
+++ b/include/cooperative_perception/clustering.hpp
@@ -229,7 +229,7 @@ template <typename Detection>
     for (auto it{std::begin(detections)}; it != std::end(detections);) {
       if (detail::squared_euclidean_distance(origin_point, *it) < distance_threshold) {
         cluster.add_detection(*it);
-        detections.erase(it);
+        it = detections.erase(it);
       } else {
         ++it;
       }


### PR DESCRIPTION
# PR Details
## Description

This PR fixes erasing elements within the `detections` map. The function now properly increments the iterator on erasure.

## Related GitHub Issue

Closes #95 

## Related Jira Key

[CDAR-440](https://usdot-carma.atlassian.net/browse/CDAR-440)

## Motivation and Context

## How Has This Been Tested?

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.


[CDAR-440]: https://usdot-carma.atlassian.net/browse/CDAR-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ