### PR TITLE
Add getters and setters for the `TrackManager`'s thresholds

### DIFF
--- a/docs/track_management/fixed_threshold_track_manager/constructor.md
+++ b/docs/track_management/fixed_threshold_track_manager/constructor.md
@@ -6,9 +6,10 @@ explicit FixedThresholdTrackManager(
     multiple_object_tracking::RemovalThreshold r
 );
 ```
+
 Constructs a `multiple_object_tracking::FixedThresholdTrackManager`.
 
 ## Parameters
 
-- `p` - occurrence threshold above which a detection will be promoted to _confirmed_
-- `r` - occurrence threshold below which a detection will be removed from management
+- `p` - occurrence threshold at or above which a detection will be promoted to _confirmed_
+- `r` - occurrence threshold at or below which a detection will be removed from management

--- a/docs/track_management/fixed_threshold_track_manager/get_promotion_threshold.md
+++ b/docs/track_management/fixed_threshold_track_manager/get_promotion_threshold.md
@@ -1,0 +1,16 @@
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::get_promotion_threshold`
+
+```cpp
+[[nodiscard]]
+auto get_promotion_threshold() const noexcept -> PromotionThreshold;
+```
+
+Gets the track manager's current promotion threshold.
+
+## Parameters
+
+(none)
+
+## Return value
+
+The current promotion threshold.

--- a/docs/track_management/fixed_threshold_track_manager/get_removal_threshold.md
+++ b/docs/track_management/fixed_threshold_track_manager/get_removal_threshold.md
@@ -1,0 +1,16 @@
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::get_removal_threshold`
+
+```cpp
+[[nodiscard]]
+auto get_removal_threshold() const noexcept -> RemovalThreshold;
+```
+
+Gets the track manager's current removal threshold.
+
+## Parameters
+
+(none)
+
+## Return value
+
+The current removal threshold.

--- a/docs/track_management/fixed_threshold_track_manager/main.md
+++ b/docs/track_management/fixed_threshold_track_manager/main.md
@@ -14,25 +14,33 @@ template <
 
 ## Member functions
 
-|                                  |                                             |
-| -------------------------------- | ------------------------------------------- |
-| [(constructor)][constructor_doc] | constructs the `FixedThresholdTrackManager` |
-| [(destructor)][destructor_doc]   | destructs the `FixedThresholdTrackManager`  |
+|                                                          |                                             |
+| -------------------------------------------------------- | ------------------------------------------- |
+| [(constructor)][constructor_doc]                         | constructs the `FixedThresholdTrackManager` |
+| [(destructor)][destructor_doc]                           | destructs the `FixedThresholdTrackManager`  |
+| [`get_promotion_threshold`][get_promotion_threshold_doc] | gets the current promotion threshold        |
+| [`get_removal_threshold`][get_removal_threshold_doc]     | gets the current removal threshold          |
 
 [constructor_doc]: constructor.md
 [destructor_doc]: destructor.md
+[get_promotion_threshold_doc]: get_promotion_threshold.md
+[get_removal_threshold_doc]: get_removal_threshold.md
 
 ### Track access
 
-|                                                    |                                                          |
-| -------------------------------------------------- | -------------------------------------------------------- |
-| [`get_tentative_tracks`][get_tentative_tracks_doc] | access a list of tracks whose status is _tentative_      |
-| [`get_confirmed_tracks`][get_confirmed_tracks_doc] | access a list of tracks whose status is _confirmed_      |
-| [`get_all_tracks`][get_all_tracks_doc]             | access a list of all managed tracks regardless of status |
+|                                                                                |                                                          |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| [`get_tentative_tracks`][get_tentative_tracks_doc]                             | access a list of tracks whose status is _tentative_      |
+| [`get_confirmed_tracks`][get_confirmed_tracks_doc]                             | access a list of tracks whose status is _confirmed_      |
+| [`get_all_tracks`][get_all_tracks_doc]                                         | access a list of all managed tracks regardless of status |
+| [`set_promotion_threshold_and_update`][set_promotion_threshold_and_update_doc] | set a new promotion threshold and update track statuses  |
+| [`set_removal_threshold_and_update`][set_promotion_threshold_and_update_doc]   | set a new removal threshold and update track list        |
 
 [get_tentative_tracks_doc]: get_tentative_tracks.md
 [get_confirmed_tracks_doc]: get_confirmed_tracks.md
 [get_all_tracks_doc]: get_all_tracks.md
+[set_promotion_threshold_and_update_doc]: set_promotion_threshold_and_update.md
+[set_removal_threshold_and_update_doc]: set_removal_threshold_and_update.md
 
 ### Modifiers
 

--- a/docs/track_management/fixed_threshold_track_manager/set_promotion_threshold_and_update.md
+++ b/docs/track_management/fixed_threshold_track_manager/set_promotion_threshold_and_update.md
@@ -1,0 +1,15 @@
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::set_promotion_threshold_and_update`
+
+```cpp
+auto set_promotion_threshold_and_update(const PromotionThreshold & threshold) noexcept -> void;
+```
+
+Sets the promotion threshold to a new value and updates the managed tracks' statuses based on the new threshold.
+
+## Parameters
+
+- `threshold` - occurrence threshold at or above which a detection will be promoted to _confirmed_
+
+## Return value
+
+(none)

--- a/docs/track_management/fixed_threshold_track_manager/set_removal_threshold_and_update.md
+++ b/docs/track_management/fixed_threshold_track_manager/set_removal_threshold_and_update.md
@@ -1,0 +1,15 @@
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::set_removal_threshold_and_update`
+
+```cpp
+auto set_removal_threshold_and_update(const RemovalThreshold & threshold) noexcept -> void;
+```
+
+Sets the removal threshold to a new value and prunes tracks based on the new threshold.
+
+## Parameters
+
+- `threshold` - occurrence threshold at or below which a detection will be removed from management
+
+## Return value
+
+(none)

--- a/include/cooperative_perception/track_management.hpp
+++ b/include/cooperative_perception/track_management.hpp
@@ -133,6 +133,46 @@ public:
     return tracks;
   }
 
+  auto set_promotion_threshold_and_update(const PromotionThreshold & threshold) noexcept -> void
+  {
+    promotion_threshold_ = threshold;
+
+    for (auto & [uuid, track] : tracks_) {
+      if (occurrences_[uuid] >= promotion_threshold_.value) {
+        statuses_[uuid] = TrackStatus::kConfirmed;
+      } else if (occurrences_[uuid] < promotion_threshold_.value) {
+        statuses_[uuid] = TrackStatus::kTentative;
+      }
+    }
+  }
+
+  [[nodiscard]] auto get_promotion_threshold() const noexcept -> PromotionThreshold
+  {
+    return promotion_threshold_;
+  }
+
+  auto set_removal_threshold_and_update(const RemovalThreshold & threshold) noexcept -> void
+  {
+    removal_threshold_ = threshold;
+
+    for (auto it{std::begin(occurrences_)}; it != std::end(occurrences_);) {
+      if (const auto occurrences{it->second}; occurrences <= removal_threshold_.value) {
+        const auto uuid{it->first};
+
+        tracks_.erase(uuid);
+        statuses_.erase(uuid);
+        it = occurrences_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+
+  [[nodiscard]] auto get_removal_threshold() const noexcept -> RemovalThreshold
+  {
+    return removal_threshold_;
+  }
+
 private:
   PromotionThreshold promotion_threshold_;
   RemovalThreshold removal_threshold_;

--- a/test/test_track_management.cpp
+++ b/test/test_track_management.cpp
@@ -65,3 +65,56 @@ TEST(TestTrackManagement, Simple)
   EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
   EXPECT_EQ(std::size(track_manager.get_all_tracks()), 0U);
 }
+
+TEST(TestTrackManagement, Getters)
+{
+  const cp::FixedThresholdTrackManager<cp::CtrvTrack> track_manager{
+    cp::PromotionThreshold{3}, cp::RemovalThreshold{1}};
+
+  EXPECT_EQ(track_manager.get_promotion_threshold().value, cp::PromotionThreshold{3U}.value);
+  EXPECT_EQ(track_manager.get_removal_threshold().value, cp::RemovalThreshold{1U}.value);
+}
+
+TEST(TestTrackManagement, Setters)
+{
+  cp::FixedThresholdTrackManager<cp::CtrvTrack> track_manager{
+    cp::PromotionThreshold{3}, cp::RemovalThreshold{1}};
+
+  cp::CtrvTrack track;
+  track.uuid = cp::Uuid{"test_track"};
+
+  cp::AssociationMap association_map;
+  association_map[cp::Uuid{"test_track"}].push_back(cp::Uuid{"test_detection"});
+
+  track_manager.add_tentative_track(track);
+
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 1U);
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
+
+  track_manager.update_track_lists(association_map);
+
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 1U);
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
+
+  track_manager.update_track_lists(association_map);
+
+  track_manager.set_promotion_threshold_and_update(cp::PromotionThreshold{1U});
+
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 1U);
+  EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
+
+  track_manager.set_promotion_threshold_and_update(cp::PromotionThreshold{10U});
+
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 1U);
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
+
+  track_manager.set_removal_threshold_and_update(cp::RemovalThreshold{5U});
+
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_all_tracks()), 0U);
+}


### PR DESCRIPTION
# PR Details
## Description

This PR adds getter and setter support for the `TrackManager` class. Users are no longer limited to specifying the threshold values only at compile time. When users set new threshold values, any track within the `TrackManager`'s internal list will be updated according to the new threshold value.

## Related GitHub Issue

Closes #99

## Related Jira Key

Closes [CDAR-450](https://usdot-carma.atlassian.net/browse/CDAR-450)

## Motivation and Context

Users should have the freedom to modify the threshold values whenever they like.

## How Has This Been Tested?

Unit tests

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-450]: https://usdot-carma.atlassian.net/browse/CDAR-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ