### PR TITLE
Add `HasAssociation` class

### DIFF
--- a/docs/main.md
+++ b/docs/main.md
@@ -2,6 +2,12 @@
 
 ## Association (detection-to-track matching)
 
+### Type definitions
+
+| Type                                       | Definition                          |
+| ------------------------------------------ | ----------------------------------- |
+| `multiple_object_tracking::AssociationMap` | `std::map<Uuid, std::vector<Uuid>>` |
+
 ### Predicates
 
 #### [`multiple_object_tracking::HasAssociation`][has_association_doc]

--- a/docs/main.md
+++ b/docs/main.md
@@ -1,5 +1,17 @@
 # Multiple object tracking library
 
+## Association (detection-to-track matching)
+
+### Predicates
+
+#### [`multiple_object_tracking::HasAssociation`][has_association_doc]
+
+This class is a function object that can be used as a unary predicate to check
+if a specified object (track or detection) has an association within a given
+association map.
+
+[has_association_doc]: track_matching/has_association/main.md
+
 ## Clustering
 
 ### [`multiple_object_tracking::Cluster`][cluster_doc]

--- a/docs/track_matching/has_association/constructor.md
+++ b/docs/track_matching/has_association/constructor.md
@@ -1,0 +1,11 @@
+# `multiple_object_tracking::HasAssociation::HasAssociation`
+
+```cpp
+explicit HasAssociation(const AssociationMap & associations);
+```
+
+Constructs a `HasAssociation`.
+
+## Parameters
+
+- `associations` - the association map that will be queried against

--- a/docs/track_matching/has_association/main.md
+++ b/docs/track_matching/has_association/main.md
@@ -1,0 +1,22 @@
+# `multiple_object_tracking::HasAssociation`
+
+Defined in `<multiple_object_tracking/track_matching.hpp>`
+
+```cpp
+class HasAssociation;
+```
+
+This class is a function object that can be used as a unary predicate to check
+if a specified object (track or detection) has an association within a given
+association map.
+
+## Member functions
+
+|                                       |                                     |
+| ------------------------------------- | ----------------------------------- |
+| [(constructor)][constructor_doc]  | constructs the `HasAssociation`     |
+| (destructor) _(implicitly declared)_  | destructs the `HasAssociation`      |
+| [`operator()`][operator_call_doc]     | checks if object has an association |
+
+[constructor_doc]: constructor.md
+[operator_call_doc]: operator_call.md

--- a/docs/track_matching/has_association/operator_call.md
+++ b/docs/track_matching/has_association/operator_call.md
@@ -1,0 +1,18 @@
+# `multiple_object_tracking::HasAssociation::operator()`
+
+```cpp
+template <typename Object>
+[[nodiscard]]
+auto operator()(const Object & object) const noexcept -> bool;
+```
+
+Checks if the specified object has an association within the `HasAssociation`'s
+internal association map.
+
+## Parameters
+
+- `object` - the object that will be checks
+
+## Return value
+
+`true` if the object has an association; `false` otherwise.

--- a/include/cooperative_perception/track_matching.hpp
+++ b/include/cooperative_perception/track_matching.hpp
@@ -41,44 +41,25 @@ namespace cooperative_perception
  */
 using AssociationMap = std::map<Uuid, std::vector<Uuid>>;
 
-class isAssociatedDetection
+class HasAssociation
 {
 public:
-  explicit isAssociatedDetection(const AssociationMap & associations)
+  explicit HasAssociation(const AssociationMap & associations)
   {
     for (const auto & [track_uuid, detection_uuids] : associations) {
+      associated_uuids_.insert(track_uuid);
       associated_uuids_.insert(std::cbegin(detection_uuids), std::cend(detection_uuids));
     }
   }
 
-  template <typename DetectionType>
-  auto operator()(const DetectionType & detection) const noexcept -> bool
+  template <typename Object>
+  auto operator()(const Object & object) const noexcept -> bool
   {
-    return associated_uuids_.count(get_uuid(detection)) != 0;
+    return associated_uuids_.count(get_uuid(object)) != 0;
   }
 
 private:
-  std::unordered_set<Uuid> associated_uuids_;
-};
-
-class isAssociatedTrack
-{
-public:
-  explicit isAssociatedTrack(const AssociationMap & associations)
-  {
-    for (const auto & [track_uuid, detection_uuids] : associations) {
-      associated_uuids_.insert(track_uuid);
-    }
-  }
-
-  template <typename TrackType>
-  auto operator()(const TrackType & track) const noexcept -> bool
-  {
-    return associated_uuids_.count(get_uuid(track)) != 0;
-  }
-
-private:
-  std::unordered_set<Uuid> associated_uuids_;
+  std::unordered_set<Uuid> associated_uuids_{};
 };
 
 /**


### PR DESCRIPTION
# PR Details
## Description

This PR removes the individual `isAssociatedTrack` and `isAssociatedDetection` class and replaces them with a single `HasAssociation` class. The new class is functionally identical.

## Related GitHub Issue

Closes #92 

## Related Jira Key

Closes [CDAR-436](https://usdot-carma.atlassian.net/browse/CDAR-436)

## Motivation and Context

It is unnecessary to have separate `isAssociatedDetection` and `isAssociatedTrack` classes when they both refer to the same association map. Having a unified class makes for a cleaner interface.

## How Has This Been Tested?

## Types of changes

- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
