### PR TITLE
Add ROS 2 package support

### DIFF
--- a/cmake/cooperative_perception_coreConfig.cmake
+++ b/cmake/cooperative_perception_coreConfig.cmake
@@ -1,4 +1,4 @@
-# Copyright 2022 Leidos
+# Copyright 2023 Leidos
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,3 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(Boost COMPONENTS container)
+find_dependency(dlib)
+find_dependency(Eigen3)
+find_dependency(nlohmann_json)
+find_dependency(units)
+
+include(${CMAKE_CURRENT_LIST_DIR}/cooperative_perception_core/cooperative_perception_coreTargets.cmake)

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -23,23 +23,7 @@ CPMAddPackage(NAME units
     "BUILD_DOCS FALSE"
 )
 
-CPMAddPackage(NAME Eigen3
-  GITLAB_REPOSITORY "libeigen/eigen"
-  GIT_TAG 3.3.7
-  DOWNLOAD_ONLY TRUE
-  OPTIONS
-    "EIGEN_BUILD_DOC FALSE"
-    "EIGEN_BUILD_TESTING FALSE"
-    "BUILD_TESTING FALSE"
-    "EIGEN_BUILD_PKGCONFIG FALSE"
-)
-
-if(Eigen3_ADDED)
-  add_library(Eigen3 INTERFACE IMPORTED GLOBAL)
-  add_library(Eigen3::Eigen ALIAS Eigen3)
-
-  target_include_directories(Eigen3 INTERFACE ${Eigen3_SOURCE_DIR})
-endif()
+find_package(Eigen3 REQUIRED)
 
 CPMAddPackage(NAME dlib
   GITHUB_REPOSITORY davisking/dlib
@@ -52,6 +36,8 @@ CPMAddPackage(NAME dlib
     "DLIB_GIF_SUPPORT FALSE"
     "DLIB_USE_MKL_FFT FALSE"
     "DLIB_USE_FFMPEG FALSE"
+    "DLIB_USE_CUDA FALSE"
+    "DLIB_IN_PROJECT_BUILD FALSE"
 )
 
 CPMAddPackage(NAME nlohmann_json

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<!--
+Copyright 2023 Leidos
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<package format="3">
+  <name>multiple_object_tracking</name>
+  <version>0.1.0</version>
+  <description>A multiple object tracking library</description>
+
+  <maintainer email="carma@dot.gov">carma</maintainer>
+
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,3 +34,32 @@ target_link_libraries(cooperative_perception_coreLibrary
     dlib::dlib
     nlohmann_json::nlohmann_json
 )
+
+set_target_properties(cooperative_perception_coreLibrary PROPERTIES
+  POSITION_INDEPENDENT_CODE TRUE
+)
+
+include(GNUInstallDirs)
+
+install(TARGETS cooperative_perception_coreLibrary
+  EXPORT cooperative_perception_coreTargets
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/cooperative_perception
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING PATTERN *.hpp
+)
+
+install(FILES ${PROJECT_SOURCE_DIR}/cmake/cooperative_perception_coreConfig.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cooperative_perception_core
+)
+
+install(EXPORT cooperative_perception_coreTargets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cooperative_perception_core/cooperative_perception_core
+  FILE cooperative_perception_coreTargets.cmake
+  NAMESPACE cooperative_perception_core::
+)


### PR DESCRIPTION
# PR Details
## Description

This PR adds necessary files and CMake configurations to support being consumed by ROS 2 packages.

## Related GitHub Issue

Closes #102 

## Related Jira Key

Closes [CDAR-467](https://usdot-carma.atlassian.net/browse/CDAR-467)

## Motivation and Context

The downstream ROS 2 package was previously consuming this library as a source dependency through `FetchContent`/CPM, but we can get `colcon` to build the `multiple_object_tracking` library as a ROS 2 package. Downstream ROS 2 packages can then consume the library through `find_package`.

## How Has This Been Tested?

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-467]: https://usdot-carma.atlassian.net/browse/CDAR-467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ