### PR TITLE
Replace `cooperative_perception` with `multiple_object_tracking`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
 
 cmake_minimum_required(VERSION 3.16)
-project(cooperative_perception_core)
+project(multiple_object_tracking)
 enable_testing()
 
 # In CMake 3.21, PROJECT_IS_TOP_LEVEL is provided, so if block can be removed when the
@@ -26,10 +26,10 @@ else()
   set(PROJECT_IS_TOP_LEVEL FALSE CACHE INTERNAL "")
 endif()
 
-option(cooperative_perception_ENABLE_TESTING "Enable unit tests for cooperative_perception" ${PROJECT_IS_TOP_LEVEL})
-option(cooperative_perception_EXPORT_COMPILE_COMMANDS "Export compile commands" ON)
+option(multiple_object_tracking_ENABLE_TESTING "Enable unit tests for multiple_object_tracking" ${PROJECT_IS_TOP_LEVEL})
+option(multiple_object_tracking_EXPORT_COMPILE_COMMANDS "Export compile commands" ON)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ${cooperative_perception_EXPORT_COMPILE_COMMANDS})
+set(CMAKE_EXPORT_COMPILE_COMMANDS ${multiple_object_tracking_EXPORT_COMPILE_COMMANDS})
 
 # Language standard is required for all project targets
 set(CMAKE_CXX_STANDARD 17)
@@ -41,6 +41,6 @@ include(dependencies.cmake)
 
 add_subdirectory(src)
 
-if(cooperative_perception_ENABLE_TESTING OR PROJECT_IS_TOP_LEVEL)
+if(multiple_object_tracking_ENABLE_TESTING OR PROJECT_IS_TOP_LEVEL)
   add_subdirectory(test)
 endif()

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ The development team would like to acknowledge the people who have made direct c
 By contributing to the Federal Highway Administration (FHWA) Connected Automated Research Mobility Applications (CARMA), you agree that your contributions will be licensed under its Apache License 2.0 license. [Project License](<docs/License.md>)
 
 ## Contact
-Please click on the CARMA logo below to visit the Federal Highway Adminstration (FHWA) CARMA website.
+Please click on the CARMA logo below to visit the Federal Highway Administration (FHWA) CARMA website.
 
 [![CARMA Image](https://raw.githubusercontent.com/usdot-fhwa-stol/carma-platform/develop/docs/image/CARMA_icon.png)](https://highways.dot.gov/research/research-programs/operations/CARMA)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cooperative-perception-core
+# Multiple object tracking
 
 ## Contribution
 Welcome to the CARMA contributing guide. Please read this guide to learn about our development process, how to propose pull requests and improvements, and how to build and test your changes to this project. [CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md)

--- a/cmake/multiple_object_trackingConfig.cmake
+++ b/cmake/multiple_object_trackingConfig.cmake
@@ -20,4 +20,4 @@ find_dependency(Eigen3)
 find_dependency(nlohmann_json)
 find_dependency(units)
 
-include(${CMAKE_CURRENT_LIST_DIR}/cooperative_perception_core/cooperative_perception_coreTargets.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/multiple_object_tracking/multiple_object_trackingTargets.cmake)

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -50,6 +50,6 @@ CPMAddPackage(NAME nlohmann_json
 
 find_package(Boost REQUIRED COMPONENTS container)
 
-if(cooperative_perception_ENABLE_TESTING OR PROJECT_IS_TOP_LEVEL)
+if(multiple_object_tracking_ENABLE_TESTING OR PROJECT_IS_TOP_LEVEL)
   CPMAddPackage("gh:google/googletest#v1.14.0")
 endif()

--- a/docs/design/ctrv_model.md
+++ b/docs/design/ctrv_model.md
@@ -26,10 +26,10 @@ using CtrvCovariance = Eigen::Matrix<float, 5, 5>;
 ### Interface
 ```cpp
 auto nextState(
-    const cooperative_perception::CtrvState& state,
-    const cooperative_perception::CtrvStateCovariance& covariance,
+    const multiple_object_tracking::CtrvState& state,
+    const multiple_object_tracking::CtrvStateCovariance& covariance,
     float time_step
-) -> std::tuple<cooperative_perception::CtrvState, cooperative_perception::CtrvStateCovariance>;
+) -> std::tuple<multiple_object_tracking::CtrvState, multiple_object_tracking::CtrvStateCovariance>;
 ```
 
 ### Parameters

--- a/docs/design/key_classes.md
+++ b/docs/design/key_classes.md
@@ -14,11 +14,11 @@ This class represents a detected object received from the host agent (HA) or a r
 
 ```cpp
 struct {
-    namespace cp = multiple_object_tracking;
+    namespace mot = multiple_object_tracking;
 
     std::chrono::time_point timestamp;
-    cp::CtrvState state;
-    cp::CtrvStateCovariance covariance;
+    mot::CtrvState state;
+    mot::CtrvStateCovariance covariance;
 };
 ```
 
@@ -46,10 +46,10 @@ This class represents a remote agent that shares its own state and detected obje
 
 ```cpp
 struct {
-    namespace cp = multiple_object_tracking;
+    namespace mot = multiple_object_tracking;
 
     std::chrono::time_point timestamp;
-    cp::CtrvState state;
-    cp::CtrvStateCovariance covariance;
+    mot::CtrvState state;
+    mot::CtrvStateCovariance covariance;
 };
 ```

--- a/docs/design/key_classes.md
+++ b/docs/design/key_classes.md
@@ -14,7 +14,7 @@ This class represents a detected object received from the host agent (HA) or a r
 
 ```cpp
 struct {
-    namespace cp = cooperative_perception;
+    namespace cp = multiple_object_tracking;
 
     std::chrono::time_point timestamp;
     cp::CtrvState state;
@@ -46,7 +46,7 @@ This class represents a remote agent that shares its own state and detected obje
 
 ```cpp
 struct {
-    namespace cp = cooperative_perception;
+    namespace cp = multiple_object_tracking;
 
     std::chrono::time_point timestamp;
     cp::CtrvState state;

--- a/docs/system_design/detected_objects.rst
+++ b/docs/system_design/detected_objects.rst
@@ -1,7 +1,7 @@
 Detected objects
 ================
 
-Detecting objects is critical to perception, and sharing those objects is critical to cooperative perception. Without
+Detecting objects is critical to perception, and sharing those objects is critical to multiple object tracking. Without
 the former, you couldn't see, and without the latter, your friends couldn't see. Detected objects move with different
 motion models depending on their type. Think about how you move when walking versus how your car moves when driving. We
 support the following object types, each with a different assumed motion model:

--- a/docs/system_design/motion_models.rst
+++ b/docs/system_design/motion_models.rst
@@ -3,7 +3,7 @@ Motion models
 
 Accurately tracking objects' motion is critical to perception tasks. Unfortunately, not all objects move the same way.
 Cyclists are agile enough to weave in and out of traffic, while buses must move carefully to avoid overturning. Our
-cooperative perception library provides several motion models that collectively represent all types of agents you
+multiple object tracking library provides several motion models that collectively represent all types of agents you
 might encounter on the roads.
 
 

--- a/include/multiple_object_tracking/angle.hpp
+++ b/include/multiple_object_tracking/angle.hpp
@@ -18,15 +18,15 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#ifndef COOPERATIVE_PERCEPTION_ANGLE_HPP
-#define COOPERATIVE_PERCEPTION_ANGLE_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_ANGLE_HPP
+#define MULTIPLE_OBJECT_TRACKING_ANGLE_HPP
 
 #include <units.h>
 
 #include <boost/math/constants/constants.hpp>
 #include <complex>
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 /**
  * @brief Angle type for representing and manipulating angles
@@ -123,5 +123,5 @@ inline auto operator/(Angle lhs, double rhs) -> Angle
   return lhs;
 }
 
-}  // namespace cooperative_perception
-#endif  // COOPERATIVE_PERCEPTION_ANGLE_HPP
+}  // namespace multiple_object_tracking
+#endif  // MULTIPLE_OBJECT_TRACKING_ANGLE_HPP

--- a/include/multiple_object_tracking/augmented_state.hpp
+++ b/include/multiple_object_tracking/augmented_state.hpp
@@ -18,13 +18,13 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#ifndef COOPERATIVE_PERCEPTION_AUGMENTED_STATE_HPP
-#define COOPERATIVE_PERCEPTION_AUGMENTED_STATE_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_AUGMENTED_STATE_HPP
+#define MULTIPLE_OBJECT_TRACKING_AUGMENTED_STATE_HPP
 
 #include <cstddef>
 #include <functional>
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 /**
  * @brief Augmented state vector containing a motion model's state vector and its process noise vector
@@ -190,6 +190,6 @@ inline auto round_to_decimal_place(
 }
 }  // namespace utils
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_AUGMENTED_STATE_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_AUGMENTED_STATE_HPP

--- a/include/multiple_object_tracking/clustering.hpp
+++ b/include/multiple_object_tracking/clustering.hpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef COOPERATIVE_PERCEPTION_CLUSTERING_HPP
-#define COOPERATIVE_PERCEPTION_CLUSTERING_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_CLUSTERING_HPP
+#define MULTIPLE_OBJECT_TRACKING_CLUSTERING_HPP
 
 #include <units.h>
 
@@ -23,13 +23,13 @@
 #include <variant>
 #include <vector>
 
-#include "cooperative_perception/angle.hpp"
-#include "cooperative_perception/ctra_model.hpp"
-#include "cooperative_perception/ctrv_model.hpp"
-#include "cooperative_perception/uuid.hpp"
-#include "cooperative_perception/visitor.hpp"
+#include "multiple_object_tracking/angle.hpp"
+#include "multiple_object_tracking/ctra_model.hpp"
+#include "multiple_object_tracking/ctrv_model.hpp"
+#include "multiple_object_tracking/uuid.hpp"
+#include "multiple_object_tracking/visitor.hpp"
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 struct Point
 {
@@ -241,6 +241,6 @@ template <typename Detection>
   return clusters;
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_CLUSTERING_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_CLUSTERING_HPP

--- a/include/multiple_object_tracking/covariance_calibration.hpp
+++ b/include/multiple_object_tracking/covariance_calibration.hpp
@@ -18,31 +18,22 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#ifndef COOPERATIVE_PERCEPTION_VISITOR_HPP
-#define COOPERATIVE_PERCEPTION_VISITOR_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_COVARIANCE_CALIBRATION_HPP
+#define MULTIPLE_OBJECT_TRACKING_COVARIANCE_CALIBRATION_HPP
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 /**
- * @brief Generic visitor class
+ * @brief Covariance Calibration
  *
- * This is a utility class to make it easier to build visitors with lambdas.
+ * @tparam DetectionType for whose covariance needs to be calibrated
  */
-template <typename... Base>
-struct Visitor : Base...
+template <typename DetectionType>
+auto calibrate_covariance(DetectionType & detection) -> void
 {
-  /**
-   * @brief Bring base class' operator overloads into this scope
-   */
-  using Base::operator()...;
-};
+  // TODO: Implement covariance calibration algorithm here
+  // Covariance calibration magic here
+}
+}  // namespace multiple_object_tracking
 
-/**
- * @brief Type deduction hint for the Visitor constructor
- */
-template <typename... T>
-Visitor(T &&... t) -> Visitor<T...>;
-
-}  // namespace cooperative_perception
-
-#endif  // COOPERATIVE_PERCEPTION_VISITOR_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_UNSCENTED_TRANSFORM_HPP

--- a/include/multiple_object_tracking/ctra_model.hpp
+++ b/include/multiple_object_tracking/ctra_model.hpp
@@ -18,8 +18,8 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#ifndef COOPERATIVE_PERCEPTION_CTRA_MODEL_HPP
-#define COOPERATIVE_PERCEPTION_CTRA_MODEL_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_CTRA_MODEL_HPP
+#define MULTIPLE_OBJECT_TRACKING_CTRA_MODEL_HPP
 
 #include <units.h>
 
@@ -29,14 +29,14 @@
 #include <cmath>
 #include <functional>
 
-#include "cooperative_perception/angle.hpp"
-#include "cooperative_perception/dynamic_object.hpp"
-#include "cooperative_perception/units.hpp"
+#include "multiple_object_tracking/angle.hpp"
+#include "multiple_object_tracking/dynamic_object.hpp"
+#include "multiple_object_tracking/units.hpp"
 
 /**
  * @brief State vector for the constant turn-rate and acceleration (CTRA) motion model
  */
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 struct CtraState
 {
@@ -409,6 +409,6 @@ inline auto round_to_decimal_place(const CtraProcessNoise & noise, std::size_t d
 
 }  // namespace utils
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_CTRA_MODEL_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_CTRA_MODEL_HPP

--- a/include/multiple_object_tracking/ctrv_model.hpp
+++ b/include/multiple_object_tracking/ctrv_model.hpp
@@ -18,8 +18,8 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#ifndef COOPERATIVE_PERCEPTION_CTRV_MODEL_HPP
-#define COOPERATIVE_PERCEPTION_CTRV_MODEL_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_CTRV_MODEL_HPP
+#define MULTIPLE_OBJECT_TRACKING_CTRV_MODEL_HPP
 
 #include <math.h>
 #include <units.h>
@@ -29,14 +29,14 @@
 #include <boost/math/special_functions/next.hpp>
 #include <functional>
 
-#include "cooperative_perception/angle.hpp"
-#include "cooperative_perception/dynamic_object.hpp"
-#include "cooperative_perception/units.hpp"
+#include "multiple_object_tracking/angle.hpp"
+#include "multiple_object_tracking/dynamic_object.hpp"
+#include "multiple_object_tracking/units.hpp"
 
 /**
  * @brief State vector for the constant turn-rate and velocity (CTRV) motion model
  */
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 struct CtrvState
 {
@@ -464,6 +464,6 @@ inline auto round_to_decimal_place(const CtrvProcessNoise & noise, std::size_t d
 
 }  // namespace utils
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_CTRV_MODEL_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_CTRV_MODEL_HPP

--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#ifndef COOPERATIVE_PERCEPTION_DYNAMIC_OBJECT_HPP
-#define COOPERATIVE_PERCEPTION_DYNAMIC_OBJECT_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_DYNAMIC_OBJECT_HPP
+#define MULTIPLE_OBJECT_TRACKING_DYNAMIC_OBJECT_HPP
 
 #include <units.h>
 
-#include "cooperative_perception/uuid.hpp"
+#include "multiple_object_tracking/uuid.hpp"
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 template <typename State, typename StateCovariance, typename Tag>
 struct DynamicObject
@@ -98,6 +98,6 @@ auto make_track(const std::variant<Alternatives...> & detection) -> Track
   return std::visit([](const auto & d) { return make_track<Track>(d); }, detection);
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_DYNAMIC_OBJECT_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_DYNAMIC_OBJECT_HPP

--- a/include/multiple_object_tracking/fusing.hpp
+++ b/include/multiple_object_tracking/fusing.hpp
@@ -19,18 +19,18 @@
  * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
-#ifndef COOPERATIVE_PERCEPTION_FUSING_HPP
-#define COOPERATIVE_PERCEPTION_FUSING_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_FUSING_HPP
+#define MULTIPLE_OBJECT_TRACKING_FUSING_HPP
 
 #include <Eigen/Dense>
 #include <tuple>
 #include <variant>
 
-#include "cooperative_perception/dynamic_object.hpp"
-#include "cooperative_perception/uuid.hpp"
-#include "cooperative_perception/visitor.hpp"
+#include "multiple_object_tracking/dynamic_object.hpp"
+#include "multiple_object_tracking/uuid.hpp"
+#include "multiple_object_tracking/visitor.hpp"
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 /**
  * @brief Compute the covariance intersection of two multivariate Gaussian distributions.
@@ -161,6 +161,6 @@ auto fuse_associations(
   return fused_tracks;
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_FUSING_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_FUSING_HPP

--- a/include/multiple_object_tracking/gating.hpp
+++ b/include/multiple_object_tracking/gating.hpp
@@ -19,14 +19,14 @@
  * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
-#ifndef COOPERATIVE_PERCEPTION_GATING_HPP
-#define COOPERATIVE_PERCEPTION_GATING_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_GATING_HPP
+#define MULTIPLE_OBJECT_TRACKING_GATING_HPP
 
 #include <vector>
 
-#include "cooperative_perception/scoring.hpp"
+#include "multiple_object_tracking/scoring.hpp"
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 template <typename UnaryPredicate>
 auto prune_track_and_detection_scores_if(ScoreMap & scores, UnaryPredicate should_prune) -> void
@@ -44,6 +44,6 @@ auto prune_track_and_detection_scores_if(ScoreMap & scores, UnaryPredicate shoul
   }
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_GATING_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_GATING_HPP

--- a/include/multiple_object_tracking/json_parsing.hpp
+++ b/include/multiple_object_tracking/json_parsing.hpp
@@ -14,33 +14,33 @@
  * limitations under the License.
  */
 
-#ifndef COOPERATIVE_PERCEPTION_JSON_PARSING_HPP
-#define COOPERATIVE_PERCEPTION_JSON_PARSING_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_JSON_PARSING_HPP
+#define MULTIPLE_OBJECT_TRACKING_JSON_PARSING_HPP
 
 #include <Eigen/Dense>
 #include <nlohmann/json.hpp>
 
-#include "cooperative_perception/ctra_model.hpp"
-#include "cooperative_perception/ctrv_model.hpp"
-#include "cooperative_perception/uuid.hpp"
+#include "multiple_object_tracking/ctra_model.hpp"
+#include "multiple_object_tracking/ctrv_model.hpp"
+#include "multiple_object_tracking/uuid.hpp"
 
 template <>
-struct nlohmann::adl_serializer<cooperative_perception::Uuid>
+struct nlohmann::adl_serializer<multiple_object_tracking::Uuid>
 {
-  static auto to_json(json & j, const cooperative_perception::Uuid & uuid) -> void {}
+  static auto to_json(json & j, const multiple_object_tracking::Uuid & uuid) -> void {}
 
-  static auto from_json(const json & j, cooperative_perception::Uuid & uuid) -> void
+  static auto from_json(const json & j, multiple_object_tracking::Uuid & uuid) -> void
   {
-    uuid = cooperative_perception::Uuid{j.template get<std::string>()};
+    uuid = multiple_object_tracking::Uuid{j.template get<std::string>()};
   }
 };
 
 template <>
-struct nlohmann::adl_serializer<cooperative_perception::CtrvState>
+struct nlohmann::adl_serializer<multiple_object_tracking::CtrvState>
 {
-  static auto to_json(json & j, const cooperative_perception::CtrvState & state) -> void {}
+  static auto to_json(json & j, const multiple_object_tracking::CtrvState & state) -> void {}
 
-  static auto from_json(const json & j, cooperative_perception::CtrvState & state) -> void
+  static auto from_json(const json & j, multiple_object_tracking::CtrvState & state) -> void
   {
     state.position_x = units::length::meter_t{j.at("position_x_m").template get<double>()};
     state.position_y = units::length::meter_t{j.at("position_y_m")};
@@ -51,11 +51,11 @@ struct nlohmann::adl_serializer<cooperative_perception::CtrvState>
 };
 
 template <>
-struct nlohmann::adl_serializer<cooperative_perception::CtraState>
+struct nlohmann::adl_serializer<multiple_object_tracking::CtraState>
 {
-  static auto to_json(json & j, const cooperative_perception::CtraState & state) -> void {}
+  static auto to_json(json & j, const multiple_object_tracking::CtraState & state) -> void {}
 
-  static auto from_json(const json & j, cooperative_perception::CtraState & state) -> void
+  static auto from_json(const json & j, multiple_object_tracking::CtraState & state) -> void
   {
     state.position_x = units::length::meter_t{j.at("position_x_m").template get<double>()};
     state.position_y = units::length::meter_t{j.at("position_y_m")};
@@ -68,14 +68,14 @@ struct nlohmann::adl_serializer<cooperative_perception::CtraState>
 };
 
 template <>
-struct nlohmann::adl_serializer<cooperative_perception::CtrvStateCovariance>
+struct nlohmann::adl_serializer<multiple_object_tracking::CtrvStateCovariance>
 {
-  static auto to_json(json & j, const cooperative_perception::CtrvStateCovariance & covariance)
+  static auto to_json(json & j, const multiple_object_tracking::CtrvStateCovariance & covariance)
     -> void
   {
   }
 
-  static auto from_json(const json & j, cooperative_perception::CtrvStateCovariance & covariance)
+  static auto from_json(const json & j, multiple_object_tracking::CtrvStateCovariance & covariance)
     -> void
   {
     auto data = j.template get<std::vector<float>>();
@@ -84,14 +84,14 @@ struct nlohmann::adl_serializer<cooperative_perception::CtrvStateCovariance>
 };
 
 template <>
-struct nlohmann::adl_serializer<cooperative_perception::CtraStateCovariance>
+struct nlohmann::adl_serializer<multiple_object_tracking::CtraStateCovariance>
 {
-  static auto to_json(json & j, const cooperative_perception::CtraStateCovariance & covariance)
+  static auto to_json(json & j, const multiple_object_tracking::CtraStateCovariance & covariance)
     -> void
   {
   }
 
-  static auto from_json(const json & j, cooperative_perception::CtraStateCovariance & covariance)
+  static auto from_json(const json & j, multiple_object_tracking::CtraStateCovariance & covariance)
     -> void
   {
     auto data = j.template get<std::vector<float>>();
@@ -100,11 +100,11 @@ struct nlohmann::adl_serializer<cooperative_perception::CtraStateCovariance>
 };
 
 template <>
-struct nlohmann::adl_serializer<cooperative_perception::CtrvDetection>
+struct nlohmann::adl_serializer<multiple_object_tracking::CtrvDetection>
 {
-  static auto to_json(json & j, const cooperative_perception::CtrvDetection & detection) -> void {}
+  static auto to_json(json & j, const multiple_object_tracking::CtrvDetection & detection) -> void {}
 
-  static auto from_json(const json & j, cooperative_perception::CtrvDetection & detection) -> void
+  static auto from_json(const json & j, multiple_object_tracking::CtrvDetection & detection) -> void
   {
     detection.timestamp = units::time::second_t{j.at("timestamp_sec").template get<double>()};
     j.at("state").get_to(detection.state);
@@ -114,11 +114,11 @@ struct nlohmann::adl_serializer<cooperative_perception::CtrvDetection>
 };
 
 template <>
-struct nlohmann::adl_serializer<cooperative_perception::CtraDetection>
+struct nlohmann::adl_serializer<multiple_object_tracking::CtraDetection>
 {
-  static auto to_json(json & j, const cooperative_perception::CtraDetection & detection) -> void {}
+  static auto to_json(json & j, const multiple_object_tracking::CtraDetection & detection) -> void {}
 
-  static auto from_json(const json & j, cooperative_perception::CtraDetection & detection) -> void
+  static auto from_json(const json & j, multiple_object_tracking::CtraDetection & detection) -> void
   {
     detection.timestamp = units::time::second_t{j.at("timestamp_sec").template get<double>()};
     j.at("state").get_to(detection.state);
@@ -128,11 +128,11 @@ struct nlohmann::adl_serializer<cooperative_perception::CtraDetection>
 };
 
 template <>
-struct nlohmann::adl_serializer<cooperative_perception::CtrvTrack>
+struct nlohmann::adl_serializer<multiple_object_tracking::CtrvTrack>
 {
-  static auto to_json(json & j, const cooperative_perception::CtrvTrack & track) -> void {}
+  static auto to_json(json & j, const multiple_object_tracking::CtrvTrack & track) -> void {}
 
-  static auto from_json(const json & j, cooperative_perception::CtrvTrack & track) -> void
+  static auto from_json(const json & j, multiple_object_tracking::CtrvTrack & track) -> void
   {
     track.timestamp = units::time::second_t{j.at("timestamp_sec").template get<double>()};
     j.at("state").get_to(track.state);
@@ -142,11 +142,11 @@ struct nlohmann::adl_serializer<cooperative_perception::CtrvTrack>
 };
 
 template <>
-struct nlohmann::adl_serializer<cooperative_perception::CtraTrack>
+struct nlohmann::adl_serializer<multiple_object_tracking::CtraTrack>
 {
-  static auto to_json(json & j, const cooperative_perception::CtraTrack & track) -> void {}
+  static auto to_json(json & j, const multiple_object_tracking::CtraTrack & track) -> void {}
 
-  static auto from_json(const json & j, cooperative_perception::CtraTrack & track) -> void
+  static auto from_json(const json & j, multiple_object_tracking::CtraTrack & track) -> void
   {
     track.timestamp = units::time::second_t{j.at("timestamp_sec").template get<double>()};
     j.at("state").get_to(track.state);
@@ -155,7 +155,7 @@ struct nlohmann::adl_serializer<cooperative_perception::CtraTrack>
   }
 };
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 namespace customization
 {
@@ -174,7 +174,7 @@ struct do_detections_from_json_file<CtrvDetection>
       const auto motion_model{detection.at("motion_model").template get<std::string>()};
 
       if (motion_model == "ctrv") {
-        detections.push_back(detection.template get<cooperative_perception::CtrvDetection>());
+        detections.push_back(detection.template get<multiple_object_tracking::CtrvDetection>());
       } else {
         throw std::runtime_error("Unsupported motion model");
       }
@@ -196,7 +196,7 @@ struct do_detections_from_json_file<CtraDetection>
       const auto motion_model{detection.at("motion_model").template get<std::string>()};
 
       if (motion_model == "ctra") {
-        detections.push_back(detection.template get<cooperative_perception::CtraDetection>());
+        detections.push_back(detection.template get<multiple_object_tracking::CtraDetection>());
       } else {
         throw std::runtime_error("Unsupported motion model");
       }
@@ -218,9 +218,9 @@ struct do_detections_from_json_file<std::variant<Alternatives...>>
       const auto motion_model{detection.at("motion_model").template get<std::string>()};
 
       if (motion_model == "ctrv") {
-        detections.push_back(detection.template get<cooperative_perception::CtrvDetection>());
+        detections.push_back(detection.template get<multiple_object_tracking::CtrvDetection>());
       } else if (motion_model == "ctra") {
-        detections.push_back(detection.template get<cooperative_perception::CtraDetection>());
+        detections.push_back(detection.template get<multiple_object_tracking::CtraDetection>());
       } else {
         throw std::runtime_error("Unsupported motion model");
       }
@@ -245,7 +245,7 @@ struct do_tracks_from_json_file<CtrvTrack>
       const auto motion_model{track.at("motion_model").template get<std::string>()};
 
       if (motion_model == "ctrv") {
-        tracks.push_back(track.template get<cooperative_perception::CtrvTrack>());
+        tracks.push_back(track.template get<multiple_object_tracking::CtrvTrack>());
       } else {
         throw std::runtime_error("Unsupported motion model");
       }
@@ -267,7 +267,7 @@ struct do_tracks_from_json_file<CtraTrack>
       const auto motion_model{track.at("motion_model").template get<std::string>()};
 
       if (motion_model == "ctra") {
-        tracks.push_back(track.template get<cooperative_perception::CtraTrack>());
+        tracks.push_back(track.template get<multiple_object_tracking::CtraTrack>());
       } else {
         throw std::runtime_error("Unsupported motion model");
       }
@@ -289,9 +289,9 @@ struct do_tracks_from_json_file<std::variant<Alternatives...>>
       const auto motion_model{track.at("motion_model").template get<std::string>()};
 
       if (motion_model == "ctrv") {
-        tracks.push_back(track.template get<cooperative_perception::CtrvTrack>());
+        tracks.push_back(track.template get<multiple_object_tracking::CtrvTrack>());
       } else if (motion_model == "ctra") {
-        tracks.push_back(track.template get<cooperative_perception::CtraTrack>());
+        tracks.push_back(track.template get<multiple_object_tracking::CtraTrack>());
       } else {
         throw std::runtime_error("Unsupported motion model");
       }
@@ -311,6 +311,6 @@ template <typename T>
 inline constexpr auto tracks_from_json_file =
   [](std::ifstream & file) { return customization::do_tracks_from_json_file<T>::_(file); };
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_JSON_PARSING_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_JSON_PARSING_HPP

--- a/include/multiple_object_tracking/remove_cvref.hpp
+++ b/include/multiple_object_tracking/remove_cvref.hpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#ifndef COOPERATIVE_PERCEPTION_REMOVE_CVREF_HPP
-#define COOPERATIVE_PERCEPTION_REMOVE_CVREF_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_REMOVE_CVREF_HPP
+#define MULTIPLE_OBJECT_TRACKING_REMOVE_CVREF_HPP
 
 #include <type_traits>
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 template <typename T>
 struct remove_cvref
@@ -30,6 +30,6 @@ struct remove_cvref
 template <typename T>
 using remove_cvref_t = typename remove_cvref<T>::type;
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_REMOVE_CVREF_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_REMOVE_CVREF_HPP

--- a/include/multiple_object_tracking/scoring.hpp
+++ b/include/multiple_object_tracking/scoring.hpp
@@ -19,8 +19,8 @@
  * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
-#ifndef COOPERATIVE_PERCEPTION_SCORING_HPP
-#define COOPERATIVE_PERCEPTION_SCORING_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_SCORING_HPP
+#define MULTIPLE_OBJECT_TRACKING_SCORING_HPP
 
 #include <map>
 #include <optional>
@@ -29,10 +29,10 @@
 #include <variant>
 #include <vector>
 
-#include "cooperative_perception/uuid.hpp"
-#include "cooperative_perception/visitor.hpp"
+#include "multiple_object_tracking/uuid.hpp"
+#include "multiple_object_tracking/visitor.hpp"
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 namespace detail
 {
@@ -111,6 +111,6 @@ auto score_tracks_and_detections(
   return scores;
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_SCORING_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_SCORING_HPP

--- a/include/multiple_object_tracking/temporal_alignment.hpp
+++ b/include/multiple_object_tracking/temporal_alignment.hpp
@@ -19,16 +19,16 @@
  * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
-#ifndef COOPERATIVE_PERCEPTION_TEMPORAL_ALIGNMENT_HPP
-#define COOPERATIVE_PERCEPTION_TEMPORAL_ALIGNMENT_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_TEMPORAL_ALIGNMENT_HPP
+#define MULTIPLE_OBJECT_TRACKING_TEMPORAL_ALIGNMENT_HPP
 
 #include <units.h>
 
 #include <variant>
 
-#include "cooperative_perception/unscented_kalman_filter.hpp"
+#include "multiple_object_tracking/unscented_kalman_filter.hpp"
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 /**
  * @brief Function object to predict a system's state and covariance using an unscented transform
@@ -106,7 +106,7 @@ auto propagate_to_time(
 {
   std::visit(
     [&propagator](auto & o, units::time::second_t t) {
-      cooperative_perception::propagate_to_time(o, t, propagator);
+      multiple_object_tracking::propagate_to_time(o, t, propagator);
     },
     object, std::variant<units::time::second_t>{time});
 }
@@ -131,6 +131,6 @@ auto predict_to_time(Object object, units::time::second_t time, const Propagator
   return object;
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_TEMPORAL_ALIGNMENT_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_TEMPORAL_ALIGNMENT_HPP

--- a/include/multiple_object_tracking/track_management.hpp
+++ b/include/multiple_object_tracking/track_management.hpp
@@ -19,13 +19,13 @@
  * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
-#ifndef COOPERATIVE_PERCEPTION_TRACK_MANAGEMENT_HPP
-#define COOPERATIVE_PERCEPTION_TRACK_MANAGEMENT_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_TRACK_MANAGEMENT_HPP
+#define MULTIPLE_OBJECT_TRACKING_TRACK_MANAGEMENT_HPP
 
-#include "cooperative_perception/track_matching.hpp"
-#include "cooperative_perception/uuid.hpp"
+#include "multiple_object_tracking/track_matching.hpp"
+#include "multiple_object_tracking/uuid.hpp"
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 template <typename Type, typename Tag>
 struct TaggedType
@@ -181,6 +181,6 @@ private:
   std::unordered_map<Uuid, std::size_t> occurrences_;
 };
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_TRACK_MANAGEMENT_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_TRACK_MANAGEMENT_HPP

--- a/include/multiple_object_tracking/track_matching.hpp
+++ b/include/multiple_object_tracking/track_matching.hpp
@@ -19,8 +19,8 @@
  * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
-#ifndef COOPERATIVE_PERCEPTION_TRACK_MATCHING_HPP
-#define COOPERATIVE_PERCEPTION_TRACK_MATCHING_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_TRACK_MATCHING_HPP
+#define MULTIPLE_OBJECT_TRACKING_TRACK_MATCHING_HPP
 
 #include <dlib/matrix.h>
 #include <dlib/optimization/max_cost_assignment.h>
@@ -31,10 +31,10 @@
 #include <unordered_set>
 #include <vector>
 
-#include "cooperative_perception/dynamic_object.hpp"
-#include "cooperative_perception/scoring.hpp"
+#include "multiple_object_tracking/dynamic_object.hpp"
+#include "multiple_object_tracking/scoring.hpp"
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 /**
  * @brief Definition of AssociationMap, which is a mapping of track UUIDs to vectors of detection UUIDs
@@ -305,6 +305,6 @@ inline auto associate_detections_to_tracks(
   return associations;
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_TRACK_MATCHING_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_TRACK_MATCHING_HPP

--- a/include/multiple_object_tracking/units.hpp
+++ b/include/multiple_object_tracking/units.hpp
@@ -18,8 +18,8 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#ifndef COOPERATIVE_PERCEPTION_UNITS_HPP
-#define COOPERATIVE_PERCEPTION_UNITS_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_UNITS_HPP
+#define MULTIPLE_OBJECT_TRACKING_UNITS_HPP
 
 #include <units.h>
 
@@ -37,13 +37,13 @@ UNIT_ADD(
 
 }  // namespace units
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 template <typename Unit>
 constexpr auto remove_units(const units::unit_t<Unit> & value) noexcept
 {
   return units::unit_cast<typename units::unit_t<Unit>::underlying_type>(value);
 }
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
 #endif

--- a/include/multiple_object_tracking/unscented_kalman_filter.hpp
+++ b/include/multiple_object_tracking/unscented_kalman_filter.hpp
@@ -18,17 +18,17 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#ifndef COOPERATIVE_PERCEPTION_UNSCENTED_KALMAN_FILTER_HPP
-#define COOPERATIVE_PERCEPTION_UNSCENTED_KALMAN_FILTER_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_UNSCENTED_KALMAN_FILTER_HPP
+#define MULTIPLE_OBJECT_TRACKING_UNSCENTED_KALMAN_FILTER_HPP
 
 #include <units.h>
 
 #include <tuple>
 #include <vector>
 
-#include "cooperative_perception/unscented_transform.hpp"
+#include "multiple_object_tracking/unscented_transform.hpp"
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 /**
  * This library breaks apart the UKF structure into two functions:
@@ -135,6 +135,6 @@ private:
   float kappa_;
 };
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_UNSCENTED_KALMAN_FILTER_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_UNSCENTED_KALMAN_FILTER_HPP

--- a/include/multiple_object_tracking/unscented_transform.hpp
+++ b/include/multiple_object_tracking/unscented_transform.hpp
@@ -18,14 +18,14 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#ifndef COOPERATIVE_PERCEPTION_UNSCENTED_TRANSFORM_HPP
-#define COOPERATIVE_PERCEPTION_UNSCENTED_TRANSFORM_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_UNSCENTED_TRANSFORM_HPP
+#define MULTIPLE_OBJECT_TRACKING_UNSCENTED_TRANSFORM_HPP
 
 #include <Eigen/Dense>
 #include <tuple>
 #include <vector>
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 /**
  * @brief Generate the scaling factor lambda for generating sigma points
@@ -197,6 +197,6 @@ inline auto generate_sigma_points_and_weights(
   return {sigma_points, Wm, Wc};
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_UNSCENTED_TRANSFORM_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_UNSCENTED_TRANSFORM_HPP

--- a/include/multiple_object_tracking/utils.hpp
+++ b/include/multiple_object_tracking/utils.hpp
@@ -18,19 +18,19 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#ifndef COOPERATIVE_PERCEPTION_UTILS_HPP
-#define COOPERATIVE_PERCEPTION_UTILS_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_UTILS_HPP
+#define MULTIPLE_OBJECT_TRACKING_UTILS_HPP
 
 #include <Eigen/Dense>
 #include <cmath>
 #include <variant>
 #include <vector>
 
-#include "cooperative_perception/ctra_model.hpp"
-#include "cooperative_perception/ctrv_model.hpp"
-#include "cooperative_perception/visitor.hpp"
+#include "multiple_object_tracking/ctra_model.hpp"
+#include "multiple_object_tracking/ctrv_model.hpp"
+#include "multiple_object_tracking/visitor.hpp"
 
-namespace cooperative_perception::utils
+namespace multiple_object_tracking::utils
 {
 /**
  * @brief Rounds a float to the nearest decimal place. Useful for comparing covariance values
@@ -98,6 +98,6 @@ inline auto print_container(const EntityContainer & entities) -> void
   }
 }
 
-}  // namespace cooperative_perception::utils
+}  // namespace multiple_object_tracking::utils
 
-#endif  // COOPERATIVE_PERCEPTION_UTILS_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_UTILS_HPP

--- a/include/multiple_object_tracking/uuid.hpp
+++ b/include/multiple_object_tracking/uuid.hpp
@@ -19,15 +19,15 @@
  * Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU).
  */
 
-#ifndef COOPERATIVE_PERCEPTION_UUID_HPP
-#define COOPERATIVE_PERCEPTION_UUID_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_UUID_HPP
+#define MULTIPLE_OBJECT_TRACKING_UUID_HPP
 
 #include <functional>
 #include <ostream>
 #include <string>
 #include <utility>
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 class Uuid
 {
@@ -81,15 +81,15 @@ inline auto operator>=(const Uuid & lhs, const Uuid & rhs) noexcept -> bool
   return lhs.value() >= rhs.value();
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
 template <>
-struct std::hash<cooperative_perception::Uuid>
+struct std::hash<multiple_object_tracking::Uuid>
 {
-  auto operator()(const cooperative_perception::Uuid & uuid) const noexcept -> std::size_t
+  auto operator()(const multiple_object_tracking::Uuid & uuid) const noexcept -> std::size_t
   {
     return std::hash<std::string>{}(uuid.value());
   }
 };
 
-#endif  // COOPERATIVE_PERCEPTION_UUID_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_UUID_HPP

--- a/include/multiple_object_tracking/visitor.hpp
+++ b/include/multiple_object_tracking/visitor.hpp
@@ -18,22 +18,31 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#ifndef COOPERATIVE_PERCEPTION_COVARIANCE_CALIBRATION_HPP
-#define COOPERATIVE_PERCEPTION_COVARIANCE_CALIBRATION_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_VISITOR_HPP
+#define MULTIPLE_OBJECT_TRACKING_VISITOR_HPP
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 /**
- * @brief Covariance Calibration
+ * @brief Generic visitor class
  *
- * @tparam DetectionType for whose covariance needs to be calibrated
+ * This is a utility class to make it easier to build visitors with lambdas.
  */
-template <typename DetectionType>
-auto calibrate_covariance(DetectionType & detection) -> void
+template <typename... Base>
+struct Visitor : Base...
 {
-  // TODO: Implement covariance calibration algorithm here
-  // Covariance calibration magic here
-}
-}  // namespace cooperative_perception
+  /**
+   * @brief Bring base class' operator overloads into this scope
+   */
+  using Base::operator()...;
+};
 
-#endif  // COOPERATIVE_PERCEPTION_UNSCENTED_TRANSFORM_HPP
+/**
+ * @brief Type deduction hint for the Visitor constructor
+ */
+template <typename... T>
+Visitor(T &&... t) -> Visitor<T...>;
+
+}  // namespace multiple_object_tracking
+
+#endif  // MULTIPLE_OBJECT_TRACKING_VISITOR_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,19 +14,19 @@
 
 # Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
 
-add_library(cooperative_perception_coreLibrary
+add_library(multiple_object_trackingLibrary
   ctrv_model.cpp
   ctra_model.cpp
 )
 
-add_library(cooperative_perception::cooperative_perception ALIAS cooperative_perception_coreLibrary)
+add_library(multiple_object_tracking::multiple_object_tracking ALIAS multiple_object_trackingLibrary)
 
-target_include_directories(cooperative_perception_coreLibrary
+target_include_directories(multiple_object_trackingLibrary
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
 
-target_link_libraries(cooperative_perception_coreLibrary
+target_link_libraries(multiple_object_trackingLibrary
   PUBLIC
     Boost::container
     Eigen3::Eigen
@@ -35,31 +35,31 @@ target_link_libraries(cooperative_perception_coreLibrary
     nlohmann_json::nlohmann_json
 )
 
-set_target_properties(cooperative_perception_coreLibrary PROPERTIES
+set_target_properties(multiple_object_trackingLibrary PROPERTIES
   POSITION_INDEPENDENT_CODE TRUE
 )
 
 include(GNUInstallDirs)
 
-install(TARGETS cooperative_perception_coreLibrary
-  EXPORT cooperative_perception_coreTargets
+install(TARGETS multiple_object_trackingLibrary
+  EXPORT multiple_object_trackingTargets
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/cooperative_perception
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/multiple_object_tracking
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   FILES_MATCHING PATTERN *.hpp
 )
 
-install(FILES ${PROJECT_SOURCE_DIR}/cmake/cooperative_perception_coreConfig.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cooperative_perception_core
+install(FILES ${PROJECT_SOURCE_DIR}/cmake/multiple_object_trackingConfig.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/multiple_object_tracking
 )
 
-install(EXPORT cooperative_perception_coreTargets
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cooperative_perception_core/cooperative_perception_core
-  FILE cooperative_perception_coreTargets.cmake
-  NAMESPACE cooperative_perception_core::
+install(EXPORT multiple_object_trackingTargets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/multiple_object_tracking/multiple_object_tracking
+  FILE multiple_object_trackingTargets.cmake
+  NAMESPACE multiple_object_tracking::
 )

--- a/src/ctra_model.cpp
+++ b/src/ctra_model.cpp
@@ -18,16 +18,16 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#include "cooperative_perception/ctra_model.hpp"
+#include "multiple_object_tracking/ctra_model.hpp"
 
 #include <units.h>
 
 #include <cmath>
 
-#include "cooperative_perception/units.hpp"
-#include "cooperative_perception/utils.hpp"
+#include "multiple_object_tracking/units.hpp"
+#include "multiple_object_tracking/utils.hpp"
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 auto get_next_state(const CtraState & state, units::time::second_t time_step) -> CtraState
 {
@@ -100,4 +100,4 @@ auto print_state(const CtraState & state) -> void
   std::cout << "acceleration: " << state.acceleration << "\n";
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking

--- a/src/ctrv_model.cpp
+++ b/src/ctrv_model.cpp
@@ -18,16 +18,16 @@
  * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
  */
 
-#include "cooperative_perception/ctrv_model.hpp"
+#include "multiple_object_tracking/ctrv_model.hpp"
 
 #include <units.h>
 
 #include <cmath>
 
-#include "cooperative_perception/units.hpp"
-#include "cooperative_perception/utils.hpp"
+#include "multiple_object_tracking/units.hpp"
+#include "multiple_object_tracking/utils.hpp"
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 auto get_next_state(const CtrvState & state, units::time::second_t time_step) -> CtrvState
 {
@@ -90,4 +90,4 @@ auto print_state(const CtrvState & state) -> void
   std::cout << "yaw rate: " << state.yaw_rate << "\n";
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 # Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
 
-add_executable(test_cooperative_perceptionExecutable
+add_executable(test_multiple_object_trackingExecutable
   test_angle.cpp
   test_ctrv_model.cpp
   test_ctra_model.cpp
@@ -31,21 +31,21 @@ add_executable(test_cooperative_perceptionExecutable
   test_track_management.cpp
 )
 
-target_include_directories(test_cooperative_perceptionExecutable
+target_include_directories(test_multiple_object_trackingExecutable
   PRIVATE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/test>
 )
 
-target_link_libraries(test_cooperative_perceptionExecutable
+target_link_libraries(test_multiple_object_trackingExecutable
   PRIVATE
-  cooperative_perception::cooperative_perception
-  GTest::gtest
-  GTest::gtest_main
-  GTest::gmock
-  GTest::gmock_main
+    multiple_object_tracking::multiple_object_tracking
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
+    GTest::gmock_main
 )
 
 include(GoogleTest)
-gtest_discover_tests(test_cooperative_perceptionExecutable
+gtest_discover_tests(test_multiple_object_trackingExecutable
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
 )

--- a/test/multiple_object_tracking/test/gmock_matchers.hpp
+++ b/test/multiple_object_tracking/test/gmock_matchers.hpp
@@ -112,14 +112,14 @@ inline constexpr auto CtrvStateNear =
     using ::testing::AllOf;
     using ::testing::Field;
 
-    namespace cp = multiple_object_tracking;
+    namespace mot = multiple_object_tracking;
 
     return AllOf(
-      Field(&cp::CtrvState::position_x, DimensionedNear(state.position_x, max_abs_error)),
-      Field(&cp::CtrvState::position_y, DimensionedNear(state.position_y, max_abs_error)),
-      Field(&cp::CtrvState::velocity, DimensionedNear(state.velocity, max_abs_error)),
-      Field(&cp::CtrvState::yaw, AngleNear(state.yaw, max_abs_error)),
-      Field(&cp::CtrvState::yaw_rate, DimensionedNear(state.yaw_rate, max_abs_error)));
+      Field(&mot::CtrvState::position_x, DimensionedNear(state.position_x, max_abs_error)),
+      Field(&mot::CtrvState::position_y, DimensionedNear(state.position_y, max_abs_error)),
+      Field(&mot::CtrvState::velocity, DimensionedNear(state.velocity, max_abs_error)),
+      Field(&mot::CtrvState::yaw, AngleNear(state.yaw, max_abs_error)),
+      Field(&mot::CtrvState::yaw_rate, DimensionedNear(state.yaw_rate, max_abs_error)));
   };
 
 inline constexpr auto CtraStateNear =
@@ -127,15 +127,15 @@ inline constexpr auto CtraStateNear =
     using ::testing::AllOf;
     using ::testing::Field;
 
-    namespace cp = multiple_object_tracking;
+    namespace mot = multiple_object_tracking;
 
     return AllOf(
-      Field(&cp::CtraState::position_x, DimensionedNear(state.position_x, max_abs_error)),
-      Field(&cp::CtraState::position_y, DimensionedNear(state.position_y, max_abs_error)),
-      Field(&cp::CtraState::velocity, DimensionedNear(state.velocity, max_abs_error)),
-      Field(&cp::CtraState::yaw, AngleNear(state.yaw, max_abs_error)),
-      Field(&cp::CtraState::yaw_rate, DimensionedNear(state.yaw_rate, max_abs_error)),
-      Field(&cp::CtraState::acceleration, DimensionedNear(state.acceleration, max_abs_error)));
+      Field(&mot::CtraState::position_x, DimensionedNear(state.position_x, max_abs_error)),
+      Field(&mot::CtraState::position_y, DimensionedNear(state.position_y, max_abs_error)),
+      Field(&mot::CtraState::velocity, DimensionedNear(state.velocity, max_abs_error)),
+      Field(&mot::CtraState::yaw, AngleNear(state.yaw, max_abs_error)),
+      Field(&mot::CtraState::yaw_rate, DimensionedNear(state.yaw_rate, max_abs_error)),
+      Field(&mot::CtraState::acceleration, DimensionedNear(state.acceleration, max_abs_error)));
   };
 
 inline constexpr auto CtrvTrackNear =
@@ -144,13 +144,13 @@ inline constexpr auto CtrvTrackNear =
     using ::testing::Eq;
     using ::testing::Field;
 
-    namespace cp = multiple_object_tracking;
+    namespace mot = multiple_object_tracking;
 
     return AllOf(
-      Field(&cp::CtrvTrack::timestamp, DimensionedNear(track.timestamp, max_abs_error)),
-      Field(&cp::CtrvTrack::state, CtrvStateNear(track.state, max_abs_error)),
-      Field(&cp::CtrvTrack::covariance, EigenMatrixNear(track.covariance, max_abs_error)),
-      Field(&cp::CtrvTrack::uuid, Eq(track.uuid)));
+      Field(&mot::CtrvTrack::timestamp, DimensionedNear(track.timestamp, max_abs_error)),
+      Field(&mot::CtrvTrack::state, CtrvStateNear(track.state, max_abs_error)),
+      Field(&mot::CtrvTrack::covariance, EigenMatrixNear(track.covariance, max_abs_error)),
+      Field(&mot::CtrvTrack::uuid, Eq(track.uuid)));
   };
 
 inline constexpr auto CtraTrackNear =
@@ -159,13 +159,13 @@ inline constexpr auto CtraTrackNear =
     using ::testing::Eq;
     using ::testing::Field;
 
-    namespace cp = multiple_object_tracking;
+    namespace mot = multiple_object_tracking;
 
     return AllOf(
-      Field(&cp::CtraTrack::timestamp, DimensionedNear(track.timestamp, max_abs_error)),
-      Field(&cp::CtraTrack::state, CtraStateNear(track.state, max_abs_error)),
-      Field(&cp::CtraTrack::covariance, EigenMatrixNear(track.covariance, max_abs_error)),
-      Field(&cp::CtraTrack::uuid, Eq(track.uuid)));
+      Field(&mot::CtraTrack::timestamp, DimensionedNear(track.timestamp, max_abs_error)),
+      Field(&mot::CtraTrack::state, CtraStateNear(track.state, max_abs_error)),
+      Field(&mot::CtraTrack::covariance, EigenMatrixNear(track.covariance, max_abs_error)),
+      Field(&mot::CtraTrack::uuid, Eq(track.uuid)));
   };
 
 namespace detail

--- a/test/multiple_object_tracking/test/gmock_matchers.hpp
+++ b/test/multiple_object_tracking/test/gmock_matchers.hpp
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-#ifndef COOPERATIVE_PERCEPTION_TEST_MATCHERS_HPP
-#define COOPERATIVE_PERCEPTION_TEST_MATCHERS_HPP
+#ifndef MULTIPLE_OBJECT_TRACKING_TEST_MATCHERS_HPP
+#define MULTIPLE_OBJECT_TRACKING_TEST_MATCHERS_HPP
 
 #include <gmock/gmock.h>
 
-#include <cooperative_perception/ctra_model.hpp>
-#include <cooperative_perception/ctrv_model.hpp>
-#include <cooperative_perception/units.hpp>
-#include <cooperative_perception/visitor.hpp>
+#include <multiple_object_tracking/ctra_model.hpp>
+#include <multiple_object_tracking/ctrv_model.hpp>
+#include <multiple_object_tracking/units.hpp>
+#include <multiple_object_tracking/visitor.hpp>
 #include <iostream>
 #include <type_traits>
 
@@ -49,7 +49,7 @@ public:
       *os << "absolute difference: " << absolute_difference;
     }
 
-    return cooperative_perception::remove_units(absolute_difference) <= max_abs_error_;
+    return multiple_object_tracking::remove_units(absolute_difference) <= max_abs_error_;
   }
 
   auto DescribeTo(std::ostream * os) const -> void
@@ -82,7 +82,7 @@ auto DimensionedNear(units::unit_t<Unit> expected, double max_abs_error)
 
 MATCHER_P2(AngleNear, angle, max_abs_error, "")
 {
-  return cooperative_perception::remove_units(
+  return multiple_object_tracking::remove_units(
            units::math::abs((arg.get_angle() - angle.get_angle()))) <= max_abs_error;
 }
 
@@ -108,11 +108,11 @@ MATCHER_P2(EigenMatrixNear, matrix, max_abs_error, "")
 }
 
 inline constexpr auto CtrvStateNear =
-  [](const cooperative_perception::CtrvState & state, double max_abs_error) {
+  [](const multiple_object_tracking::CtrvState & state, double max_abs_error) {
     using ::testing::AllOf;
     using ::testing::Field;
 
-    namespace cp = cooperative_perception;
+    namespace cp = multiple_object_tracking;
 
     return AllOf(
       Field(&cp::CtrvState::position_x, DimensionedNear(state.position_x, max_abs_error)),
@@ -123,11 +123,11 @@ inline constexpr auto CtrvStateNear =
   };
 
 inline constexpr auto CtraStateNear =
-  [](const cooperative_perception::CtraState & state, double max_abs_error) {
+  [](const multiple_object_tracking::CtraState & state, double max_abs_error) {
     using ::testing::AllOf;
     using ::testing::Field;
 
-    namespace cp = cooperative_perception;
+    namespace cp = multiple_object_tracking;
 
     return AllOf(
       Field(&cp::CtraState::position_x, DimensionedNear(state.position_x, max_abs_error)),
@@ -139,12 +139,12 @@ inline constexpr auto CtraStateNear =
   };
 
 inline constexpr auto CtrvTrackNear =
-  [](const cooperative_perception::CtrvTrack & track, double max_abs_error) {
+  [](const multiple_object_tracking::CtrvTrack & track, double max_abs_error) {
     using ::testing::AllOf;
     using ::testing::Eq;
     using ::testing::Field;
 
-    namespace cp = cooperative_perception;
+    namespace cp = multiple_object_tracking;
 
     return AllOf(
       Field(&cp::CtrvTrack::timestamp, DimensionedNear(track.timestamp, max_abs_error)),
@@ -154,12 +154,12 @@ inline constexpr auto CtrvTrackNear =
   };
 
 inline constexpr auto CtraTrackNear =
-  [](const cooperative_perception::CtraTrack & track, double max_abs_error) {
+  [](const multiple_object_tracking::CtraTrack & track, double max_abs_error) {
     using ::testing::AllOf;
     using ::testing::Eq;
     using ::testing::Field;
 
-    namespace cp = cooperative_perception;
+    namespace cp = multiple_object_tracking;
 
     return AllOf(
       Field(&cp::CtraTrack::timestamp, DimensionedNear(track.timestamp, max_abs_error)),
@@ -179,7 +179,7 @@ public:
 
   auto MatchAndExplain(
     const std::tuple<
-      const cooperative_perception::CtrvTrack &, const cooperative_perception::CtrvTrack &> & arg,
+      const multiple_object_tracking::CtrvTrack &, const multiple_object_tracking::CtrvTrack &> & arg,
     std::ostream *) const -> bool
   {
     using ::testing::Matches;
@@ -192,7 +192,7 @@ public:
 
   auto MatchAndExplain(
     const std::tuple<
-      const cooperative_perception::CtraTrack &, const cooperative_perception::CtraTrack &> & arg,
+      const multiple_object_tracking::CtraTrack &, const multiple_object_tracking::CtraTrack &> & arg,
     std::ostream *) const -> bool
   {
     using ::testing::Matches;
@@ -209,10 +209,10 @@ public:
       arg,
     std::ostream *) const -> bool
   {
-    using cooperative_perception::CtraTrack;
-    using cooperative_perception::CtrvTrack;
+    using multiple_object_tracking::CtraTrack;
+    using multiple_object_tracking::CtrvTrack;
 
-    const cooperative_perception::Visitor visitor{
+    const multiple_object_tracking::Visitor visitor{
       [this](const CtrvTrack & actual, const CtrvTrack & expected) {
         return Matches(CtrvTrackNear(expected, max_abs_error_))(actual);
       },
@@ -249,7 +249,7 @@ inline auto PointwiseTrackNear(double max_abs_error) noexcept -> detail::Pointwi
   return detail::PointwiseTrackNearMatcher{max_abs_error};
 }
 
-namespace cooperative_perception
+namespace multiple_object_tracking
 {
 inline auto PrintTo(const CtrvTrack & track, std::ostream * os) noexcept -> void
 {
@@ -280,6 +280,6 @@ inline auto PrintTo(const CtraTrack & track, std::ostream * os) noexcept -> void
   *os << "    uuid: " << track.uuid.value() << '\n';
 }
 
-}  // namespace cooperative_perception
+}  // namespace multiple_object_tracking
 
-#endif  // COOPERATIVE_PERCEPTION_TEST_MATCHERS_HPP
+#endif  // MULTIPLE_OBJECT_TRACKING_TEST_MATCHERS_HPP

--- a/test/test_angle.cpp
+++ b/test/test_angle.cpp
@@ -28,7 +28,7 @@
 
 using namespace units::literals;
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
 /**
  * Test CTRV get_next_state function against pure rotation
@@ -36,17 +36,17 @@ namespace cp = multiple_object_tracking;
 TEST(TestAngle, AngleArithmeticOperations)
 {
   // Define some known angles
-  const auto angle_pi{cp::Angle{3.141592654_rad}};
-  const auto angle_pi_2{cp::Angle{1.570796327_rad}};
-  const auto angle_pi_4{cp::Angle{0.785398163_rad}};
-  const auto angle_pi_6{cp::Angle{0.523598776_rad}};
+  const auto angle_pi{mot::Angle{3.141592654_rad}};
+  const auto angle_pi_2{mot::Angle{1.570796327_rad}};
+  const auto angle_pi_4{mot::Angle{0.785398163_rad}};
+  const auto angle_pi_6{mot::Angle{0.523598776_rad}};
 
   // Perform additive and scalar operations
-  auto res1 = cp::remove_units((angle_pi / 2.0).get_angle());
-  auto res2 = cp::remove_units((angle_pi_4 * 2.0).get_angle());
-  auto res3 = cp::remove_units((angle_pi + angle_pi_2).get_angle());
-  auto res4 = cp::remove_units((angle_pi - angle_pi_4).get_angle());
-  auto res5 = cp::remove_units((angle_pi * 2.2).get_angle());
+  auto res1 = mot::remove_units((angle_pi / 2.0).get_angle());
+  auto res2 = mot::remove_units((angle_pi_4 * 2.0).get_angle());
+  auto res3 = mot::remove_units((angle_pi + angle_pi_2).get_angle());
+  auto res4 = mot::remove_units((angle_pi - angle_pi_4).get_angle());
+  auto res5 = mot::remove_units((angle_pi * 2.2).get_angle());
 
   // Set tolerance for these tests
   constexpr double tolerance = 1.e-8;
@@ -62,13 +62,13 @@ TEST(TestAngle, AngleBooleanOperations)
 {
   static constexpr double tolerance{1.e-8};
 
-  const auto angle_pi{cp::Angle{3.141592654_rad}};
-  const auto angle_pi_2{cp::Angle{1.570796327_rad}};
+  const auto angle_pi{mot::Angle{3.141592654_rad}};
+  const auto angle_pi_2{mot::Angle{1.570796327_rad}};
   const auto angle_difference{angle_pi - angle_pi_2};
 
-  const auto angle_pi_raw{cp::remove_units(angle_pi.get_angle())};
-  const auto angle_pi_2_raw{cp::remove_units(angle_pi_2.get_angle())};
-  const auto angle_difference_raw{cp::remove_units(angle_difference.get_angle())};
+  const auto angle_pi_raw{mot::remove_units(angle_pi.get_angle())};
+  const auto angle_pi_2_raw{mot::remove_units(angle_pi_2.get_angle())};
+  const auto angle_difference_raw{mot::remove_units(angle_difference.get_angle())};
 
   using ::testing::DoubleNear;
   using ::testing::Not;

--- a/test/test_angle.cpp
+++ b/test/test_angle.cpp
@@ -23,12 +23,12 @@
 #include <units.h>
 
 #include <boost/math/constants/constants.hpp>
-#include <cooperative_perception/angle.hpp>
-#include <cooperative_perception/units.hpp>
+#include <multiple_object_tracking/angle.hpp>
+#include <multiple_object_tracking/units.hpp>
 
 using namespace units::literals;
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 /**
  * Test CTRV get_next_state function against pure rotation

--- a/test/test_clustering.cpp
+++ b/test/test_clustering.cpp
@@ -1,12 +1,12 @@
 #include <gtest/gtest.h>
 
-#include <cooperative_perception/clustering.hpp>
-#include <cooperative_perception/ctra_model.hpp>
-#include <cooperative_perception/ctrv_model.hpp>
-#include <cooperative_perception/json_parsing.hpp>
+#include <multiple_object_tracking/clustering.hpp>
+#include <multiple_object_tracking/ctra_model.hpp>
+#include <multiple_object_tracking/ctrv_model.hpp>
+#include <multiple_object_tracking/json_parsing.hpp>
 #include <fstream>
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 TEST(TestCluster, Empty)
 {

--- a/test/test_clustering.cpp
+++ b/test/test_clustering.cpp
@@ -6,11 +6,11 @@
 #include <multiple_object_tracking/json_parsing.hpp>
 #include <fstream>
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
 TEST(TestCluster, Empty)
 {
-  cp::Cluster<cp::CtraDetection> cluster;
+  mot::Cluster<mot::CtraDetection> cluster;
 
   ASSERT_TRUE(cluster.is_empty());
   EXPECT_THROW((void)cluster.get_centroid(), std::runtime_error);
@@ -18,11 +18,11 @@ TEST(TestCluster, Empty)
 
 TEST(TestCluser, Simple)
 {
-  cp::Cluster<cp::CtrvDetection> cluster;
+  mot::Cluster<mot::CtrvDetection> cluster;
 
-  cp::CtrvDetection detection;
+  mot::CtrvDetection detection;
   detection.state.position_x = units::length::meter_t{1.0};
-  detection.uuid = cp::Uuid{"detection1"};
+  detection.uuid = mot::Uuid{"detection1"};
 
   cluster.add_detection(detection);
   auto centroid{cluster.get_centroid()};
@@ -35,7 +35,7 @@ TEST(TestCluser, Simple)
   EXPECT_EQ(centroid.yaw_rate, units::angular_velocity::radians_per_second_t{0.0});
 
   detection.state.position_x = units::length::meter_t{3.0};
-  detection.uuid = cp::Uuid{"detection2"};
+  detection.uuid = mot::Uuid{"detection2"};
   cluster.add_detection(detection);
   centroid = cluster.get_centroid();
 
@@ -47,7 +47,7 @@ TEST(TestCluser, Simple)
   EXPECT_EQ(centroid.yaw_rate, units::angular_velocity::radians_per_second_t{0.0});
 
   detection.state.position_x = units::length::meter_t{5.0};
-  detection.uuid = cp::Uuid{"detection3"};
+  detection.uuid = mot::Uuid{"detection3"};
   cluster.add_detection(detection);
   centroid = cluster.get_centroid();
 
@@ -58,7 +58,7 @@ TEST(TestCluser, Simple)
   EXPECT_EQ(centroid.yaw.get_angle(), units::angle::radian_t{0.0});
   EXPECT_EQ(centroid.yaw_rate, units::angular_velocity::radians_per_second_t{0.0});
 
-  cluster.remove_detection(cp::Uuid{"detection3"});
+  cluster.remove_detection(mot::Uuid{"detection3"});
   centroid = cluster.get_centroid();
 
   // This will use the operator== overload, which for units library is almost-equality
@@ -74,10 +74,10 @@ TEST(TestClustering, Disjoint)
   std::ifstream detections_file{"data/test_clustering_disjoint.json"};
   ASSERT_TRUE(detections_file);
 
-  const auto detections{cp::detections_from_json_file<cp::CtrvDetection>(detections_file)};
+  const auto detections{mot::detections_from_json_file<mot::CtrvDetection>(detections_file)};
 
-  EXPECT_EQ(std::size(cp::cluster_detections(detections, 1.0)), 2U);
-  EXPECT_EQ(std::size(cp::cluster_detections(detections, 3.0)), 1U);
+  EXPECT_EQ(std::size(mot::cluster_detections(detections, 1.0)), 2U);
+  EXPECT_EQ(std::size(mot::cluster_detections(detections, 3.0)), 1U);
 }
 
 TEST(TestClustering, Overlapping)
@@ -85,8 +85,8 @@ TEST(TestClustering, Overlapping)
   std::ifstream detections_file{"data/test_clustering_overlapping.json"};
   ASSERT_TRUE(detections_file);
 
-  const auto detections{cp::detections_from_json_file<cp::CtrvDetection>(detections_file)};
+  const auto detections{mot::detections_from_json_file<mot::CtrvDetection>(detections_file)};
 
-  EXPECT_EQ(std::size(cp::cluster_detections(detections, 1.0)), 1U);
-  EXPECT_EQ(std::size(cp::cluster_detections(detections, 3.0)), 1U);
+  EXPECT_EQ(std::size(mot::cluster_detections(detections, 1.0)), 1U);
+  EXPECT_EQ(std::size(mot::cluster_detections(detections, 3.0)), 1U);
 }

--- a/test/test_ctra_model.cpp
+++ b/test/test_ctra_model.cpp
@@ -21,13 +21,13 @@
 #include <gtest/gtest.h>
 #include <units.h>
 
-#include <cooperative_perception/angle.hpp>
-#include <cooperative_perception/ctra_model.hpp>
-#include <cooperative_perception/units.hpp>
+#include <multiple_object_tracking/angle.hpp>
+#include <multiple_object_tracking/ctra_model.hpp>
+#include <multiple_object_tracking/units.hpp>
 
-#include "cooperative_perception/test/gmock_matchers.hpp"
+#include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 /**
  * Test CTRA get_next_state function against pure rotation

--- a/test/test_ctra_model.cpp
+++ b/test/test_ctra_model.cpp
@@ -27,7 +27,7 @@
 
 #include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
 /**
  * Test CTRA get_next_state function against pure rotation
@@ -36,9 +36,9 @@ TEST(TestCtraModel, NextStatePureRotation)
 {
   using namespace units::literals;
 
-  const cp::CtraState state{0_m, 0_m, 0_mps, cp::Angle(0_rad), 1_rad_per_s, 0_mps_sq};
-  const auto next_state{cp::get_next_state(state, 0.5_s)};
-  const cp::CtraState expected_state{0_m, 0_m, 0_mps, cp::Angle(0.5_rad), 1_rad_per_s, 0_mps_sq};
+  const mot::CtraState state{0_m, 0_m, 0_mps, mot::Angle(0_rad), 1_rad_per_s, 0_mps_sq};
+  const auto next_state{mot::get_next_state(state, 0.5_s)};
+  const mot::CtraState expected_state{0_m, 0_m, 0_mps, mot::Angle(0.5_rad), 1_rad_per_s, 0_mps_sq};
 
   EXPECT_THAT(next_state, CtraStateNear(expected_state, 1e-9));
 }
@@ -50,10 +50,10 @@ TEST(TestCtraModel, NextStatePureTranslation)
 {
   using namespace units::literals;
 
-  const cp::CtraState state{0_m, 0_m, 1_mps, cp::Angle(0_rad), 0_rad_per_s, 1_mps_sq};
-  const auto next_state{cp::get_next_state(state, 0.5_s)};
-  const cp::CtraState expected_state{0.625_m,          0_m,         1.5_mps,
-                                     cp::Angle(0_rad), 0_rad_per_s, 1_mps_sq};
+  const mot::CtraState state{0_m, 0_m, 1_mps, mot::Angle(0_rad), 0_rad_per_s, 1_mps_sq};
+  const auto next_state{mot::get_next_state(state, 0.5_s)};
+  const mot::CtraState expected_state{0.625_m,          0_m,         1.5_mps,
+                                     mot::Angle(0_rad), 0_rad_per_s, 1_mps_sq};
 
   EXPECT_THAT(next_state, CtraStateNear(expected_state, 1e-9));
 }
@@ -65,10 +65,10 @@ TEST(TestCtraModel, NextStateRotationAndTranslation)
 {
   using namespace units::literals;
 
-  const cp::CtraState state{0_m, 0_m, 1_mps, cp::Angle(0_rad), 1_rad_per_s, 1_mps_sq};
-  const auto next_state{cp::get_next_state(state, 0.5_s)};
-  const cp::CtraState expected_state{0.5967208697966773_m, 0.16305169576864387_m, 1.5_mps,
-                                     cp::Angle(0.5_rad),   1_rad_per_s,           1_mps_sq};
+  const mot::CtraState state{0_m, 0_m, 1_mps, mot::Angle(0_rad), 1_rad_per_s, 1_mps_sq};
+  const auto next_state{mot::get_next_state(state, 0.5_s)};
+  const mot::CtraState expected_state{0.5967208697966773_m, 0.16305169576864387_m, 1.5_mps,
+                                     mot::Angle(0.5_rad),   1_rad_per_s,           1_mps_sq};
 
   EXPECT_THAT(next_state, CtraStateNear(expected_state, 1e-9));
 }
@@ -77,13 +77,13 @@ TEST(TestCtraModel, Equality)
 {
   using namespace units::literals;
 
-  const cp::CtraState state1{
-    1.23_m, 2.435_m, 5544_mps, cp::Angle(34656.6543_rad), 595633.555_rad_per_s, 100_mps_sq};
-  const cp::CtraState state2{
-    1.23_m, 2.435_m, 5544_mps, cp::Angle(34656.6543_rad), 595633.555_rad_per_s, 100_mps_sq};
-  const cp::CtraState state3{
-    1_m, 2_m, 4_mps, cp::Angle(3_rad), 1.000000000000000000000000001_rad_per_s, 1_mps_sq};
-  const cp::CtraState state4{1_m, 2_m, 4_mps, cp::Angle(3_rad), 1_rad_per_s, 1_mps_sq};
+  const mot::CtraState state1{
+    1.23_m, 2.435_m, 5544_mps, mot::Angle(34656.6543_rad), 595633.555_rad_per_s, 100_mps_sq};
+  const mot::CtraState state2{
+    1.23_m, 2.435_m, 5544_mps, mot::Angle(34656.6543_rad), 595633.555_rad_per_s, 100_mps_sq};
+  const mot::CtraState state3{
+    1_m, 2_m, 4_mps, mot::Angle(3_rad), 1.000000000000000000000000001_rad_per_s, 1_mps_sq};
+  const mot::CtraState state4{1_m, 2_m, 4_mps, mot::Angle(3_rad), 1_rad_per_s, 1_mps_sq};
 
   EXPECT_THAT(state1, CtraStateNear(state1, 1e-9));
   EXPECT_THAT(state1, CtraStateNear(state2, 1e-9));

--- a/test/test_ctrv_model.cpp
+++ b/test/test_ctrv_model.cpp
@@ -21,13 +21,13 @@
 #include <gtest/gtest.h>
 #include <units.h>
 
-#include <cooperative_perception/angle.hpp>
-#include <cooperative_perception/ctrv_model.hpp>
-#include <cooperative_perception/units.hpp>
+#include <multiple_object_tracking/angle.hpp>
+#include <multiple_object_tracking/ctrv_model.hpp>
+#include <multiple_object_tracking/units.hpp>
 
-#include "cooperative_perception/test/gmock_matchers.hpp"
+#include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 /**
  * Test CTRV get_next_state function against pure rotation

--- a/test/test_ctrv_model.cpp
+++ b/test/test_ctrv_model.cpp
@@ -27,7 +27,7 @@
 
 #include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
 /**
  * Test CTRV get_next_state function against pure rotation
@@ -36,9 +36,9 @@ TEST(TestCtrvModel, NextStatePureRotation)
 {
   using namespace units::literals;
 
-  const cp::CtrvState state{0_m, 0_m, 0_mps, cp::Angle(0_rad), 1_rad_per_s};
-  const auto next_state{cp::get_next_state(state, 0.5_s)};
-  const cp::CtrvState expected_state{0_m, 0_m, 0_mps, cp::Angle(0.5_rad), 1_rad_per_s};
+  const mot::CtrvState state{0_m, 0_m, 0_mps, mot::Angle(0_rad), 1_rad_per_s};
+  const auto next_state{mot::get_next_state(state, 0.5_s)};
+  const mot::CtrvState expected_state{0_m, 0_m, 0_mps, mot::Angle(0.5_rad), 1_rad_per_s};
 
   EXPECT_THAT(next_state, CtrvStateNear(expected_state, 1e-9));
 }
@@ -50,9 +50,9 @@ TEST(TestCtrvModel, NextStatePureTranslation)
 {
   using namespace units::literals;
 
-  const cp::CtrvState state{0_m, 0_m, 1_mps, cp::Angle(0_rad), 0_rad_per_s};
-  const auto next_state{cp::get_next_state(state, 0.5_s)};
-  const cp::CtrvState expected_state{0.5_m, 0_m, 1_mps, cp::Angle(0_rad), 0_rad_per_s};
+  const mot::CtrvState state{0_m, 0_m, 1_mps, mot::Angle(0_rad), 0_rad_per_s};
+  const auto next_state{mot::get_next_state(state, 0.5_s)};
+  const mot::CtrvState expected_state{0.5_m, 0_m, 1_mps, mot::Angle(0_rad), 0_rad_per_s};
 
   EXPECT_THAT(next_state, CtrvStateNear(expected_state, 1e-9));
 }
@@ -64,10 +64,10 @@ TEST(TestCtrvModel, NextStateRotationAndTranslation)
 {
   using namespace units::literals;
 
-  const cp::CtrvState state{0_m, 0_m, 1_mps, cp::Angle(0_rad), 1_rad_per_s};
-  const auto next_state{cp::get_next_state(state, 0.5_s)};
-  const cp::CtrvState expected_state{
-    0.479425539_m, 0.122417438_m, 1_mps, cp::Angle(0.5_rad), 1_rad_per_s};
+  const mot::CtrvState state{0_m, 0_m, 1_mps, mot::Angle(0_rad), 1_rad_per_s};
+  const auto next_state{mot::get_next_state(state, 0.5_s)};
+  const mot::CtrvState expected_state{
+    0.479425539_m, 0.122417438_m, 1_mps, mot::Angle(0.5_rad), 1_rad_per_s};
 
   EXPECT_THAT(next_state, CtrvStateNear(expected_state, 1e-9));
 }
@@ -76,11 +76,11 @@ TEST(TestCtrvModel, NextStateStochastic)
 {
   using namespace units::literals;
 
-  const cp::CtrvState state{0_m, 0_m, 1_mps, cp::Angle(0_rad), 1_rad_per_s};
-  constexpr cp::CtrvProcessNoise noise{1_mps_sq, 1_rad_per_s_sq};
-  const auto next_state{cp::get_next_state(state, 0.5_s, noise)};
-  const cp::CtrvState expected_state{
-    0.604425539_m, 0.122417438_m, 1.5_mps, cp::Angle(0.625_rad), 1.5_rad_per_s};
+  const mot::CtrvState state{0_m, 0_m, 1_mps, mot::Angle(0_rad), 1_rad_per_s};
+  constexpr mot::CtrvProcessNoise noise{1_mps_sq, 1_rad_per_s_sq};
+  const auto next_state{mot::get_next_state(state, 0.5_s, noise)};
+  const mot::CtrvState expected_state{
+    0.604425539_m, 0.122417438_m, 1.5_mps, mot::Angle(0.625_rad), 1.5_rad_per_s};
 
   EXPECT_THAT(next_state, CtrvStateNear(expected_state, 1e-9));
 }
@@ -89,12 +89,12 @@ TEST(TestCtrvModel, Equality)
 {
   using namespace units::literals;
 
-  const cp::CtrvState state1{
-    1.23_m, 2.435_m, 5544_mps, cp::Angle(34656.6543_rad), 595633.555_rad_per_s};
-  const cp::CtrvState state2{1.2_m, 20.45_m, 4_mps, cp::Angle(34656.65435_rad), 5953.55_rad_per_s};
-  const cp::CtrvState state3{
-    1_m, 2_m, 4_mps, cp::Angle(3_rad), 1.000000000000000000000000001_rad_per_s};
-  const cp::CtrvState state4{1_m, 2_m, 4_mps, cp::Angle(3_rad), 1_rad_per_s};
+  const mot::CtrvState state1{
+    1.23_m, 2.435_m, 5544_mps, mot::Angle(34656.6543_rad), 595633.555_rad_per_s};
+  const mot::CtrvState state2{1.2_m, 20.45_m, 4_mps, mot::Angle(34656.65435_rad), 5953.55_rad_per_s};
+  const mot::CtrvState state3{
+    1_m, 2_m, 4_mps, mot::Angle(3_rad), 1.000000000000000000000000001_rad_per_s};
+  const mot::CtrvState state4{1_m, 2_m, 4_mps, mot::Angle(3_rad), 1_rad_per_s};
 
   using ::testing::Not;
 

--- a/test/test_detection.cpp
+++ b/test/test_detection.cpp
@@ -24,15 +24,15 @@
 #include <multiple_object_tracking/angle.hpp>
 #include <multiple_object_tracking/ctrv_model.hpp>
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
 TEST(TestDetection, CtrvDetectionDefaultConstruction)
 {
   using namespace units::literals;
 
-  auto const detection = cp::Detection<cp::CtrvState, cp::CtrvStateCovariance>{
-    units::time::second_t{0}, cp::CtrvState{0_m, 0_m, 0_mps, cp::Angle(0_rad), 0_rad_per_s},
-    cp::CtrvStateCovariance{}, cp::Uuid{""}};
+  auto const detection = mot::Detection<mot::CtrvState, mot::CtrvStateCovariance>{
+    units::time::second_t{0}, mot::CtrvState{0_m, 0_m, 0_mps, mot::Angle(0_rad), 0_rad_per_s},
+    mot::CtrvStateCovariance{}, mot::Uuid{""}};
 
   EXPECT_DOUBLE_EQ(units::unit_cast<double>(detection.timestamp), 0.0);
   EXPECT_DOUBLE_EQ(units::unit_cast<double>(detection.state.position_x), 0.0);
@@ -47,9 +47,9 @@ TEST(TestDetection, CtrvDetectionCustomConstruction)
   using namespace units::literals;
 
   // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
-  auto const detection = cp::Detection<cp::CtrvState, cp::CtrvStateCovariance>{
-    units::time::second_t{1}, cp::CtrvState{1_m, 2_m, 3_mps, 4_rad, 5_rad_per_s},
-    cp::CtrvStateCovariance{}, cp::Uuid{""}};
+  auto const detection = mot::Detection<mot::CtrvState, mot::CtrvStateCovariance>{
+    units::time::second_t{1}, mot::CtrvState{1_m, 2_m, 3_mps, 4_rad, 5_rad_per_s},
+    mot::CtrvStateCovariance{}, mot::Uuid{""}};
   // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
 
   EXPECT_DOUBLE_EQ(units::unit_cast<double>(detection.timestamp), 1.0);

--- a/test/test_detection.cpp
+++ b/test/test_detection.cpp
@@ -21,10 +21,10 @@
 #include <gtest/gtest.h>
 #include <units.h>
 
-#include <cooperative_perception/angle.hpp>
-#include <cooperative_perception/ctrv_model.hpp>
+#include <multiple_object_tracking/angle.hpp>
+#include <multiple_object_tracking/ctrv_model.hpp>
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 TEST(TestDetection, CtrvDetectionDefaultConstruction)
 {

--- a/test/test_fusing.cpp
+++ b/test/test_fusing.cpp
@@ -34,10 +34,10 @@
 
 #include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
-using DetectionVariant = std::variant<cp::CtrvDetection, cp::CtraDetection>;
-using TrackVariant = std::variant<cp::CtrvTrack, cp::CtraTrack>;
+using DetectionVariant = std::variant<mot::CtrvDetection, mot::CtraDetection>;
+using TrackVariant = std::variant<mot::CtrvTrack, mot::CtraTrack>;
 
 /**
  * Test the generate_weight function
@@ -55,7 +55,7 @@ TEST(TestFusing, GenerateWeight)
   const auto expected_weight{0.5895104895104895};
 
   // Call the function under test
-  const auto result_weight{cp::generate_weight(covariance1.inverse(), covariance2.inverse())};
+  const auto result_weight{mot::generate_weight(covariance1.inverse(), covariance2.inverse())};
 
   // Check that function returns expected value
   EXPECT_FLOAT_EQ(result_weight, expected_weight);
@@ -85,10 +85,10 @@ TEST(TestFusing, ComputeCovarianceIntersectionPureEigen)
   const auto inverse_covariance2{covariance2.inverse()};
 
   // Generate weight for CI function
-  const auto weight{cp::generate_weight(inverse_covariance1, inverse_covariance2)};
+  const auto weight{mot::generate_weight(inverse_covariance1, inverse_covariance2)};
 
   // Call the function under test
-  const auto [result_mean, result_covariance]{cp::compute_covariance_intersection(
+  const auto [result_mean, result_covariance]{mot::compute_covariance_intersection(
     mean1, inverse_covariance1, mean2, inverse_covariance2, weight)};
 
   static constexpr double tolerance{1.e-6};
@@ -104,26 +104,26 @@ TEST(TestFusing, CtrvTracksAndDetections)
 {
   using namespace units::literals;
 
-  const cp::AssociationMap associations{
-    {cp::Uuid{"track1"}, {cp::Uuid{"detection3"}}},
-    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
-    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
+  const mot::AssociationMap associations{
+    {mot::Uuid{"track1"}, {mot::Uuid{"detection3"}}},
+    {mot::Uuid{"track2"}, {mot::Uuid{"detection2"}}},
+    {mot::Uuid{"track3"}, {mot::Uuid{"detection1"}}}};
 
   std::ifstream tracks_file{"data/test_fusing_ctrv_tracks_and_detections_tracks.json"};
   ASSERT_TRUE(tracks_file);
-  const auto tracks{cp::tracks_from_json_file<TrackVariant>(tracks_file)};
+  const auto tracks{mot::tracks_from_json_file<TrackVariant>(tracks_file)};
 
   std::ifstream detections_file{"data/test_fusing_ctrv_tracks_and_detections_detections.json"};
   ASSERT_TRUE(detections_file);
-  const auto detections{cp::detections_from_json_file<DetectionVariant>(detections_file)};
+  const auto detections{mot::detections_from_json_file<DetectionVariant>(detections_file)};
 
   std::ifstream expected_tracks_file{
     "data/test_fusing_ctrv_tracks_and_detections_expected_tracks.json"};
   ASSERT_TRUE(expected_tracks_file);
-  const auto expected_tracks{cp::tracks_from_json_file<TrackVariant>(expected_tracks_file)};
+  const auto expected_tracks{mot::tracks_from_json_file<TrackVariant>(expected_tracks_file)};
 
   const auto result_tracks{
-    cp::fuse_associations(associations, tracks, detections, cp::covariance_intersection_visitor)};
+    mot::fuse_associations(associations, tracks, detections, mot::covariance_intersection_visitor)};
 
   ASSERT_EQ(std::size(result_tracks), std::size(expected_tracks));
 
@@ -139,26 +139,26 @@ TEST(TestFusing, CtraTracksAndDetections)
 {
   using namespace units::literals;
 
-  cp::AssociationMap associations{
-    {cp::Uuid{"track1"}, {cp::Uuid{"detection3"}}},
-    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
-    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
+  mot::AssociationMap associations{
+    {mot::Uuid{"track1"}, {mot::Uuid{"detection3"}}},
+    {mot::Uuid{"track2"}, {mot::Uuid{"detection2"}}},
+    {mot::Uuid{"track3"}, {mot::Uuid{"detection1"}}}};
 
   std::ifstream tracks_file{"data/test_fusing_ctra_tracks_and_detections_tracks.json"};
   ASSERT_TRUE(tracks_file);
-  const auto tracks{cp::tracks_from_json_file<TrackVariant>(tracks_file)};
+  const auto tracks{mot::tracks_from_json_file<TrackVariant>(tracks_file)};
 
   std::ifstream detections_file{"data/test_fusing_ctra_tracks_and_detections_detections.json"};
   ASSERT_TRUE(detections_file);
-  const auto detections{cp::detections_from_json_file<DetectionVariant>(detections_file)};
+  const auto detections{mot::detections_from_json_file<DetectionVariant>(detections_file)};
 
   std::ifstream expected_tracks_file{
     "data/test_fusing_ctra_tracks_and_detections_expected_tracks.json"};
   ASSERT_TRUE(expected_tracks_file);
-  const auto expected_tracks{cp::tracks_from_json_file<TrackVariant>(expected_tracks_file)};
+  const auto expected_tracks{mot::tracks_from_json_file<TrackVariant>(expected_tracks_file)};
 
   const auto result_tracks{
-    cp::fuse_associations(associations, tracks, detections, cp::covariance_intersection_visitor)};
+    mot::fuse_associations(associations, tracks, detections, mot::covariance_intersection_visitor)};
 
   ASSERT_EQ(std::size(result_tracks), std::size(expected_tracks));
 
@@ -174,26 +174,26 @@ TEST(TestFusing, MixedTracksAndDetections)
 {
   using namespace units::literals;
 
-  cp::AssociationMap associations{
-    {cp::Uuid{"track1"}, {cp::Uuid{"detection3"}}},
-    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
-    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
+  mot::AssociationMap associations{
+    {mot::Uuid{"track1"}, {mot::Uuid{"detection3"}}},
+    {mot::Uuid{"track2"}, {mot::Uuid{"detection2"}}},
+    {mot::Uuid{"track3"}, {mot::Uuid{"detection1"}}}};
 
   std::ifstream tracks_file{"data/test_fusing_mixed_tracks_and_detections_tracks.json"};
   ASSERT_TRUE(tracks_file);
-  const auto tracks{cp::tracks_from_json_file<TrackVariant>(tracks_file)};
+  const auto tracks{mot::tracks_from_json_file<TrackVariant>(tracks_file)};
 
   std::ifstream detections_file{"data/test_fusing_mixed_tracks_and_detections_detections.json"};
   ASSERT_TRUE(detections_file);
-  const auto detections{cp::detections_from_json_file<DetectionVariant>(detections_file)};
+  const auto detections{mot::detections_from_json_file<DetectionVariant>(detections_file)};
 
   std::ifstream expected_tracks_file{
     "data/test_fusing_mixed_tracks_and_detections_expected_tracks.json"};
   ASSERT_TRUE(expected_tracks_file);
-  const auto expected_tracks{cp::tracks_from_json_file<TrackVariant>(expected_tracks_file)};
+  const auto expected_tracks{mot::tracks_from_json_file<TrackVariant>(expected_tracks_file)};
 
   const auto result_tracks{
-    cp::fuse_associations(associations, tracks, detections, cp::covariance_intersection_visitor)};
+    mot::fuse_associations(associations, tracks, detections, mot::covariance_intersection_visitor)};
 
   using ::testing::Pointwise;
 
@@ -208,23 +208,23 @@ TEST(TestFusing, UnmatchedAssociations)
   using namespace units::literals;
 
   // Declaring initial values
-  cp::AssociationMap associations{
-    {cp::Uuid{"track1"}, {cp::Uuid{"detection4"}}},
-    {cp::Uuid{"track2"}, {cp::Uuid{"detection5"}}},
-    {cp::Uuid{"track3"}, {cp::Uuid{"detection6"}}}};
+  mot::AssociationMap associations{
+    {mot::Uuid{"track1"}, {mot::Uuid{"detection4"}}},
+    {mot::Uuid{"track2"}, {mot::Uuid{"detection5"}}},
+    {mot::Uuid{"track3"}, {mot::Uuid{"detection6"}}}};
 
   std::ifstream tracks_file{"data/test_fusing_unmatched_associations_tracks.json"};
   ASSERT_TRUE(tracks_file);
-  const auto tracks{cp::tracks_from_json_file<TrackVariant>(tracks_file)};
+  const auto tracks{mot::tracks_from_json_file<TrackVariant>(tracks_file)};
 
   std::ifstream detections_file{"data/test_fusing_unmatched_associations_detections.json"};
   ASSERT_TRUE(detections_file);
-  const auto detections{cp::detections_from_json_file<DetectionVariant>(detections_file)};
+  const auto detections{mot::detections_from_json_file<DetectionVariant>(detections_file)};
 
   std::vector<TrackVariant> expected_tracks;
 
   const auto result_tracks{
-    cp::fuse_associations(associations, tracks, detections, cp::covariance_intersection_visitor)};
+    mot::fuse_associations(associations, tracks, detections, mot::covariance_intersection_visitor)};
 
   using ::testing::Pointwise;
 
@@ -238,26 +238,26 @@ TEST(TestFusing, PartialMatchedAssociations)
 {
   using namespace units::literals;
 
-  cp::AssociationMap associations{
-    {cp::Uuid{"track1"}, {cp::Uuid{"detection4"}}},
-    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
-    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
+  mot::AssociationMap associations{
+    {mot::Uuid{"track1"}, {mot::Uuid{"detection4"}}},
+    {mot::Uuid{"track2"}, {mot::Uuid{"detection2"}}},
+    {mot::Uuid{"track3"}, {mot::Uuid{"detection1"}}}};
 
   std::ifstream tracks_file{"data/test_fusing_partial_matched_associations_tracks.json"};
   ASSERT_TRUE(tracks_file);
-  const auto tracks{cp::tracks_from_json_file<TrackVariant>(tracks_file)};
+  const auto tracks{mot::tracks_from_json_file<TrackVariant>(tracks_file)};
 
   std::ifstream detections_file{"data/test_fusing_partial_matched_associations_detections.json"};
   ASSERT_TRUE(detections_file);
-  const auto detections{cp::detections_from_json_file<DetectionVariant>(detections_file)};
+  const auto detections{mot::detections_from_json_file<DetectionVariant>(detections_file)};
 
   std::ifstream expected_tracks_file{
     "data/test_fusing_partial_matched_associations_expected_tracks.json"};
   ASSERT_TRUE(expected_tracks_file);
-  const auto expected_tracks{cp::tracks_from_json_file<TrackVariant>(expected_tracks_file)};
+  const auto expected_tracks{mot::tracks_from_json_file<TrackVariant>(expected_tracks_file)};
 
   const auto result_tracks{
-    cp::fuse_associations(associations, tracks, detections, cp::covariance_intersection_visitor)};
+    mot::fuse_associations(associations, tracks, detections, mot::covariance_intersection_visitor)};
 
   using ::testing::Pointwise;
 

--- a/test/test_fusing.cpp
+++ b/test/test_fusing.cpp
@@ -23,18 +23,18 @@
 #include <gtest/gtest.h>
 
 #include <Eigen/Dense>
-#include <cooperative_perception/angle.hpp>
-#include <cooperative_perception/ctra_model.hpp>
-#include <cooperative_perception/ctrv_model.hpp>
-#include <cooperative_perception/dynamic_object.hpp>
-#include <cooperative_perception/fusing.hpp>
-#include <cooperative_perception/json_parsing.hpp>
-#include <cooperative_perception/track_matching.hpp>
-#include <cooperative_perception/utils.hpp>
+#include <multiple_object_tracking/angle.hpp>
+#include <multiple_object_tracking/ctra_model.hpp>
+#include <multiple_object_tracking/ctrv_model.hpp>
+#include <multiple_object_tracking/dynamic_object.hpp>
+#include <multiple_object_tracking/fusing.hpp>
+#include <multiple_object_tracking/json_parsing.hpp>
+#include <multiple_object_tracking/track_matching.hpp>
+#include <multiple_object_tracking/utils.hpp>
 
-#include "cooperative_perception/test/gmock_matchers.hpp"
+#include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 using DetectionVariant = std::variant<cp::CtrvDetection, cp::CtraDetection>;
 using TrackVariant = std::variant<cp::CtrvTrack, cp::CtraTrack>;

--- a/test/test_gating.cpp
+++ b/test/test_gating.cpp
@@ -24,20 +24,20 @@
 #include <multiple_object_tracking/gating.hpp>
 #include <multiple_object_tracking/scoring.hpp>
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
 TEST(TestGating, TestPruning)
 {
-  cp::ScoreMap scores{
-    {{cp::Uuid{"track1"}, cp::Uuid{"detection1"}}, 10.0},
-    {{cp::Uuid{"track2"}, cp::Uuid{"detection2"}}, 20.0},
-    {{cp::Uuid{"track3"}, cp::Uuid{"detection3"}}, 30.0}};
+  mot::ScoreMap scores{
+    {{mot::Uuid{"track1"}, mot::Uuid{"detection1"}}, 10.0},
+    {{mot::Uuid{"track2"}, mot::Uuid{"detection2"}}, 20.0},
+    {{mot::Uuid{"track3"}, mot::Uuid{"detection3"}}, 30.0}};
 
-  const cp::ScoreMap expected_pruned_scores{
-    {{cp::Uuid{"track1"}, cp::Uuid{"detection1"}}, 10.0},
-    {{cp::Uuid{"track2"}, cp::Uuid{"detection2"}}, 20.0}};
+  const mot::ScoreMap expected_pruned_scores{
+    {{mot::Uuid{"track1"}, mot::Uuid{"detection1"}}, 10.0},
+    {{mot::Uuid{"track2"}, mot::Uuid{"detection2"}}, 20.0}};
 
-  cp::prune_track_and_detection_scores_if(scores, [](const auto & score) { return score > 25.0; });
+  mot::prune_track_and_detection_scores_if(scores, [](const auto & score) { return score > 25.0; });
 
   EXPECT_EQ(std::size(scores), std::size(expected_pruned_scores));
 

--- a/test/test_gating.cpp
+++ b/test/test_gating.cpp
@@ -21,10 +21,10 @@
 
 #include <gtest/gtest.h>
 
-#include <cooperative_perception/gating.hpp>
-#include <cooperative_perception/scoring.hpp>
+#include <multiple_object_tracking/gating.hpp>
+#include <multiple_object_tracking/scoring.hpp>
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 TEST(TestGating, TestPruning)
 {

--- a/test/test_json_parsing.cpp
+++ b/test/test_json_parsing.cpp
@@ -16,8 +16,8 @@
 
 #include <gtest/gtest.h>
 
-#include <cooperative_perception/dynamic_object.hpp>
-#include <cooperative_perception/json_parsing.hpp>
+#include <multiple_object_tracking/dynamic_object.hpp>
+#include <multiple_object_tracking/json_parsing.hpp>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -29,7 +29,7 @@ TEST(JsonParsing, CtrvDetection)
   ASSERT_TRUE(file);
   const auto data = nlohmann::json::parse(file);
 
-  const auto detection{data.template get<cooperative_perception::CtrvDetection>()};
+  const auto detection{data.template get<multiple_object_tracking::CtrvDetection>()};
 
   Eigen::Matrix<float, 5, 5> expected_covariance;
   expected_covariance << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,

--- a/test/test_scoring.cpp
+++ b/test/test_scoring.cpp
@@ -29,25 +29,25 @@
 #include <multiple_object_tracking/scoring.hpp>
 #include <fstream>
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
-using DetectionVariant = std::variant<cp::CtrvDetection, cp::CtraDetection>;
-using TrackVariant = std::variant<cp::CtrvTrack, cp::CtraTrack>;
+using DetectionVariant = std::variant<mot::CtrvDetection, mot::CtraDetection>;
+using TrackVariant = std::variant<mot::CtrvTrack, mot::CtraTrack>;
 
 TEST(TestScoring, CtrvEuclideanDistance)
 {
   using namespace units::literals;
 
-  using TestDetection = cp::Detection<cp::CtrvState, cp::CtrvStateCovariance>;
-  using TestTrack = cp::Track<cp::CtrvState, cp::CtrvStateCovariance>;
+  using TestDetection = mot::Detection<mot::CtrvState, mot::CtrvStateCovariance>;
+  using TestTrack = mot::Track<mot::CtrvState, mot::CtrvStateCovariance>;
 
   const auto detection = TestDetection{
-    .state{cp::CtrvState{1_m, 2_m, 3_mps, cp::Angle(3_rad), 5_rad_per_s}}, .uuid{cp::Uuid{""}}};
+    .state{mot::CtrvState{1_m, 2_m, 3_mps, mot::Angle(3_rad), 5_rad_per_s}}, .uuid{mot::Uuid{""}}};
 
   const auto track = TestTrack{
-    .state{cp::CtrvState{6_m, 7_m, 8_mps, cp::Angle(3_rad), 10_rad_per_s}}, .uuid{cp::Uuid{""}}};
+    .state{mot::CtrvState{6_m, 7_m, 8_mps, mot::Angle(3_rad), 10_rad_per_s}}, .uuid{mot::Uuid{""}}};
 
-  const auto score = cp::euclidean_distance_score(detection, track);
+  const auto score = mot::euclidean_distance_score(detection, track);
   ASSERT_TRUE(score.has_value());
   EXPECT_FLOAT_EQ(score.value(), 7.0710678118654755F);
 }
@@ -56,24 +56,24 @@ TEST(TestScoring, CtrvMahalanobisDistance)
 {
   using namespace units::literals;
 
-  using TestDetection = cp::Detection<cp::CtrvState, cp::CtrvStateCovariance>;
-  using TestTrack = cp::Track<cp::CtrvState, cp::CtrvStateCovariance>;
+  using TestDetection = mot::Detection<mot::CtrvState, mot::CtrvStateCovariance>;
+  using TestTrack = mot::Track<mot::CtrvState, mot::CtrvStateCovariance>;
 
   const auto detection = TestDetection{
-    .state{cp::CtrvState{1_m, 2_m, 3_mps, cp::Angle(3_rad), 5_rad_per_s}}, .uuid{cp::Uuid{""}}};
+    .state{mot::CtrvState{1_m, 2_m, 3_mps, mot::Angle(3_rad), 5_rad_per_s}}, .uuid{mot::Uuid{""}}};
 
-  cp::CtrvStateCovariance covariance;
+  mot::CtrvStateCovariance covariance;
   covariance << 0.0043, -0.0013, 0.0030, -0.0022, -0.0020, -0.0013, 0.0077, 0.0011, 0.0071, 0.0060,
     0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.0022, 0.0071, 0.0007, 0.0098, 0.0100, -0.0020,
     0.0060, 0.0008, 0.0100, 0.0123;
 
   const auto track = TestTrack{
-    .state{cp::CtrvState{5.7441_m, 1.3800_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.3528_rad_per_s}},
+    .state{mot::CtrvState{5.7441_m, 1.3800_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.3528_rad_per_s}},
     .covariance = covariance,
-    .uuid{cp::Uuid{""}}};
+    .uuid{mot::Uuid{""}}};
 
   const auto mahalanobis_dist =
-    cp::mahalanobis_distance(track.state, track.covariance, detection.state);
+    mot::mahalanobis_distance(track.state, track.covariance, detection.state);
   EXPECT_FLOAT_EQ(mahalanobis_dist, 74.37377728947332F);
 }
 
@@ -81,17 +81,17 @@ TEST(TestScoring, CtraEuclideanDistance)
 {
   using namespace units::literals;
 
-  const auto detection = cp::Detection<cp::CtraState, cp::CtraStateCovariance>{
+  const auto detection = mot::Detection<mot::CtraState, mot::CtraStateCovariance>{
     .timestamp{units::time::second_t{0}},
-    .state{cp::CtraState{1_m, 2_m, 3_mps, cp::Angle(3_rad), 5_rad_per_s, 6_mps_sq}},
-    .uuid{cp::Uuid{""}}};
+    .state{mot::CtraState{1_m, 2_m, 3_mps, mot::Angle(3_rad), 5_rad_per_s, 6_mps_sq}},
+    .uuid{mot::Uuid{""}}};
 
-  const auto track = cp::Track<cp::CtraState, cp::CtraStateCovariance>{
+  const auto track = mot::Track<mot::CtraState, mot::CtraStateCovariance>{
     .timestamp{units::time::second_t{0}},
-    .state{cp::CtraState{6_m, 7_m, 8_mps, cp::Angle(3_rad), 10_rad_per_s, 12_mps_sq}},
-    .uuid{cp::Uuid{""}}};
+    .state{mot::CtraState{6_m, 7_m, 8_mps, mot::Angle(3_rad), 10_rad_per_s, 12_mps_sq}},
+    .uuid{mot::Uuid{""}}};
 
-  const auto score = cp::euclidean_distance_score(detection, track);
+  const auto score = mot::euclidean_distance_score(detection, track);
   ASSERT_TRUE(score.has_value());
   EXPECT_FLOAT_EQ(score.value(), 7.0710678118654755);
 }
@@ -100,26 +100,26 @@ TEST(TestScoring, CtraMahalanobisDistance)
 {
   using namespace units::literals;
 
-  using TestDetection = cp::Detection<cp::CtraState, cp::CtraStateCovariance>;
-  using TestTrack = cp::Track<cp::CtraState, cp::CtraStateCovariance>;
+  using TestDetection = mot::Detection<mot::CtraState, mot::CtraStateCovariance>;
+  using TestTrack = mot::Track<mot::CtraState, mot::CtraStateCovariance>;
 
   const auto detection = TestDetection{
-    .state{cp::CtraState{1_m, 2_m, 3_mps, cp::Angle(3_rad), 5_rad_per_s, 6_mps_sq}},
-    .uuid{cp::Uuid{""}}};
+    .state{mot::CtraState{1_m, 2_m, 3_mps, mot::Angle(3_rad), 5_rad_per_s, 6_mps_sq}},
+    .uuid{mot::Uuid{""}}};
 
-  cp::CtraStateCovariance covariance;
+  mot::CtraStateCovariance covariance;
   covariance << 0.0043, -0.0013, 0.0030, -0.0022, -0.0020, 0.5, -0.0013, 0.0077, 0.0011, 0.0071,
     0.0060, 0.123, 0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.34, -0.0022, 0.0071, 0.0007, 0.0098,
     0.0100, 0.009, -0.0020, 0.0060, 0.0008, 0.0100, 0.0123, 0.0021, 0.5, 0.123, -0.34, 0.009,
     0.0021, -0.8701;
 
   const auto track = TestTrack{
-    .state{cp::CtraState{6_m, 7_m, 8_mps, cp::Angle(3_rad), 10_rad_per_s, 12_mps_sq}},
+    .state{mot::CtraState{6_m, 7_m, 8_mps, mot::Angle(3_rad), 10_rad_per_s, 12_mps_sq}},
     .covariance = covariance,
-    .uuid{cp::Uuid{""}}};
+    .uuid{mot::Uuid{""}}};
 
   const auto mahalanobis_dist =
-    cp::mahalanobis_distance(track.state, track.covariance, detection.state);
+    mot::mahalanobis_distance(track.state, track.covariance, detection.state);
   EXPECT_FLOAT_EQ(mahalanobis_dist, 122.3575692494651);
 }
 
@@ -127,38 +127,38 @@ TEST(TestScoring, TrackToDetectionScoringEuclidean)
 {
   using namespace units::literals;
 
-  using TestDetection = cp::Detection<cp::CtraState, cp::CtraStateCovariance>;
-  using TestTrack = cp::Track<cp::CtraState, cp::CtraStateCovariance>;
+  using TestDetection = mot::Detection<mot::CtraState, mot::CtraStateCovariance>;
+  using TestTrack = mot::Track<mot::CtraState, mot::CtraStateCovariance>;
 
   const std::vector<TrackVariant> tracks{
     TestTrack{
-      .state{cp::CtraState{6_m, 7_m, 8_mps, cp::Angle(3_rad), 10_rad_per_s, 12_mps_sq}},
-      .uuid{cp::Uuid{"test_track1"}}},
+      .state{mot::CtraState{6_m, 7_m, 8_mps, mot::Angle(3_rad), 10_rad_per_s, 12_mps_sq}},
+      .uuid{mot::Uuid{"test_track1"}}},
     TestTrack{
-      .state{cp::CtraState{8_m, 2_m, 3_mps, cp::Angle(1_rad), 12_rad_per_s, 11_mps_sq}},
-      .uuid{cp::Uuid{"test_track2"}}},
-    cp::Track<cp::CtrvState, cp::CtrvStateCovariance>{
-      .state{1_m, 1_m, 1_mps, cp::Angle(1_rad), 1_rad_per_s}, .uuid{cp::Uuid{"test_track3"}}}};
+      .state{mot::CtraState{8_m, 2_m, 3_mps, mot::Angle(1_rad), 12_rad_per_s, 11_mps_sq}},
+      .uuid{mot::Uuid{"test_track2"}}},
+    mot::Track<mot::CtrvState, mot::CtrvStateCovariance>{
+      .state{1_m, 1_m, 1_mps, mot::Angle(1_rad), 1_rad_per_s}, .uuid{mot::Uuid{"test_track3"}}}};
 
   const std::vector<DetectionVariant> detections{
     TestDetection{
-      .state{cp::CtraState{1_m, 2_m, 3_mps, cp::Angle(3_rad), 5_rad_per_s, 6_mps_sq}},
-      .uuid{cp::Uuid{"test_detection1"}}},
+      .state{mot::CtraState{1_m, 2_m, 3_mps, mot::Angle(3_rad), 5_rad_per_s, 6_mps_sq}},
+      .uuid{mot::Uuid{"test_detection1"}}},
     TestDetection{
-      .state{cp::CtraState{2_m, 3_m, 6_mps, cp::Angle(2_rad), 20_rad_per_s, 9_mps_sq}},
-      .uuid{cp::Uuid{"test_detection2"}}},
-    cp::Detection<cp::CtrvState, cp::CtrvStateCovariance>{
-      .state{1_m, 1_m, 1_mps, cp::Angle(1_rad), 1_rad_per_s}, .uuid{cp::Uuid{"test_detection3"}}}};
+      .state{mot::CtraState{2_m, 3_m, 6_mps, mot::Angle(2_rad), 20_rad_per_s, 9_mps_sq}},
+      .uuid{mot::Uuid{"test_detection2"}}},
+    mot::Detection<mot::CtrvState, mot::CtrvStateCovariance>{
+      .state{1_m, 1_m, 1_mps, mot::Angle(1_rad), 1_rad_per_s}, .uuid{mot::Uuid{"test_detection3"}}}};
 
   const auto scores =
-    cp::score_tracks_and_detections(tracks, detections, cp::euclidean_distance_score);
+    mot::score_tracks_and_detections(tracks, detections, mot::euclidean_distance_score);
 
-  const cp::ScoreMap expected_scores{
-    {std::pair{cp::Uuid{"test_track1"}, cp::Uuid{"test_detection1"}}, 7.0710678},
-    {std::pair{cp::Uuid{"test_track1"}, cp::Uuid{"test_detection2"}}, 5.7445626},
-    {std::pair{cp::Uuid{"test_track2"}, cp::Uuid{"test_detection1"}}, 7.2801099},
-    {std::pair{cp::Uuid{"test_track2"}, cp::Uuid{"test_detection2"}}, 6.1644139},
-    {std::pair{cp::Uuid{"test_track3"}, cp::Uuid{"test_detection3"}}, 0.0},
+  const mot::ScoreMap expected_scores{
+    {std::pair{mot::Uuid{"test_track1"}, mot::Uuid{"test_detection1"}}, 7.0710678},
+    {std::pair{mot::Uuid{"test_track1"}, mot::Uuid{"test_detection2"}}, 5.7445626},
+    {std::pair{mot::Uuid{"test_track2"}, mot::Uuid{"test_detection1"}}, 7.2801099},
+    {std::pair{mot::Uuid{"test_track2"}, mot::Uuid{"test_detection2"}}, 6.1644139},
+    {std::pair{mot::Uuid{"test_track3"}, mot::Uuid{"test_detection3"}}, 0.0},
   };
 
   EXPECT_EQ(std::size(scores), std::size(expected_scores));
@@ -172,17 +172,17 @@ TEST(TestScoring, TrackToDetectionScoringMahalanobis)
 {
   using namespace units::literals;
 
-  using TestDetection = cp::Detection<cp::CtraState, cp::CtraStateCovariance>;
-  using TestTrack = cp::Track<cp::CtraState, cp::CtraStateCovariance>;
+  using TestDetection = mot::Detection<mot::CtraState, mot::CtraStateCovariance>;
+  using TestTrack = mot::Track<mot::CtraState, mot::CtraStateCovariance>;
 
   std::ifstream tracks_file{"data/test_scoring_track_to_detection_scoring_mahalanobis_tracks.json"};
   ASSERT_TRUE(tracks_file);
-  const auto tracks{cp::tracks_from_json_file<TrackVariant>(tracks_file)};
+  const auto tracks{mot::tracks_from_json_file<TrackVariant>(tracks_file)};
 
   // const std::vector<TrackVariant> tracks{
   //   TestTrack{
-  //     .state{cp::CtraState{6_m, 7_m, 8_mps, cp::Angle(3_rad), 10_rad_per_s, 12_mps_sq}},
-  //     .covariance{cp::CtraStateCovariance{
+  //     .state{mot::CtraState{6_m, 7_m, 8_mps, mot::Angle(3_rad), 10_rad_per_s, 12_mps_sq}},
+  //     .covariance{mot::CtraStateCovariance{
   //       {0.0043, -0.0013, 0.0030, -0.0022, -0.0020, 0.5},
   //       {-0.0013, 0.0077, 0.0011, 0.0071, 0.0060, 0.123},
   //       {0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.34},
@@ -190,10 +190,10 @@ TEST(TestScoring, TrackToDetectionScoringMahalanobis)
   //       {-0.0020, 0.0060, 0.0008, 0.0100, 0.0123, 0.0021},
   //       {0.5, 0.123, -0.34, 0.009, 0.0021, -0.8701},
   //     }},
-  //     .uuid{cp::Uuid{"test_track1"}}},
+  //     .uuid{mot::Uuid{"test_track1"}}},
   //   TestTrack{
-  //     .state{cp::CtraState{8_m, 2_m, 3_mps, cp::Angle(1_rad), 12_rad_per_s, 11_mps_sq}},
-  //     .covariance{cp::CtraStateCovariance{
+  //     .state{mot::CtraState{8_m, 2_m, 3_mps, mot::Angle(1_rad), 12_rad_per_s, 11_mps_sq}},
+  //     .covariance{mot::CtraStateCovariance{
   //       {0.0043, -0.0013, 0.0030, -0.0022, -0.0020, 0.5},
   //       {-0.0013, 0.0077, 0.0011, 0.0071, 0.0060, 0.123},
   //       {0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.34},
@@ -201,36 +201,36 @@ TEST(TestScoring, TrackToDetectionScoringMahalanobis)
   //       {-0.0020, 0.0060, 0.0008, 0.0100, 0.0123, 0.0021},
   //       {0.5, 0.123, -0.34, 0.009, 0.0021, -0.8701},
   //     }},
-  //     .uuid{cp::Uuid{"test_track2"}}},
-  //   cp::Track<cp::CtrvState, cp::CtrvStateCovariance>{
-  //     .state{1_m, 1_m, 1_mps, cp::Angle(1_rad), 1_rad_per_s},
-  //     .covariance{cp::CtrvStateCovariance{
+  //     .uuid{mot::Uuid{"test_track2"}}},
+  //   mot::Track<mot::CtrvState, mot::CtrvStateCovariance>{
+  //     .state{1_m, 1_m, 1_mps, mot::Angle(1_rad), 1_rad_per_s},
+  //     .covariance{mot::CtrvStateCovariance{
   //       {0.0043, -0.0013, 0.0030, -0.0022, -0.0020},
   //       {-0.0013, 0.0077, 0.0011, 0.0071, 0.0060},
   //       {0.0030, 0.0011, 0.0054, 0.0007, 0.0008},
   //       {-0.0022, 0.0071, 0.0007, 0.0098, 0.0100},
   //       {-0.0020, 0.0060, 0.0008, 0.0100, 0.0123}}},
-  //     .uuid{cp::Uuid{"test_track3"}}}};
+  //     .uuid{mot::Uuid{"test_track3"}}}};
 
   const std::vector<DetectionVariant> detections{
     TestDetection{
-      .state{cp::CtraState{1_m, 2_m, 3_mps, cp::Angle(3_rad), 5_rad_per_s, 6_mps_sq}},
-      .uuid{cp::Uuid{"test_detection1"}}},
+      .state{mot::CtraState{1_m, 2_m, 3_mps, mot::Angle(3_rad), 5_rad_per_s, 6_mps_sq}},
+      .uuid{mot::Uuid{"test_detection1"}}},
     TestDetection{
-      .state{cp::CtraState{2_m, 3_m, 6_mps, cp::Angle(2_rad), 20_rad_per_s, 9_mps_sq}},
-      .uuid{cp::Uuid{"test_detection2"}}},
-    cp::Detection<cp::CtrvState, cp::CtrvStateCovariance>{
-      .state{1_m, 1_m, 1_mps, cp::Angle(1_rad), 1_rad_per_s}, .uuid{cp::Uuid{"test_detection3"}}}};
+      .state{mot::CtraState{2_m, 3_m, 6_mps, mot::Angle(2_rad), 20_rad_per_s, 9_mps_sq}},
+      .uuid{mot::Uuid{"test_detection2"}}},
+    mot::Detection<mot::CtrvState, mot::CtrvStateCovariance>{
+      .state{1_m, 1_m, 1_mps, mot::Angle(1_rad), 1_rad_per_s}, .uuid{mot::Uuid{"test_detection3"}}}};
 
   const auto scores =
-    cp::score_tracks_and_detections(tracks, detections, cp::mahalanobis_distance_score);
+    mot::score_tracks_and_detections(tracks, detections, mot::mahalanobis_distance_score);
 
-  const cp::ScoreMap expected_scores{
-    {std::pair{cp::Uuid{"test_track1"}, cp::Uuid{"test_detection1"}}, 122.35757},
-    {std::pair{cp::Uuid{"test_track1"}, cp::Uuid{"test_detection2"}}, 90.688416},
-    {std::pair{cp::Uuid{"test_track2"}, cp::Uuid{"test_detection1"}}, 109.70312},
-    {std::pair{cp::Uuid{"test_track2"}, cp::Uuid{"test_detection2"}}, 95.243896},
-    {std::pair{cp::Uuid{"test_track3"}, cp::Uuid{"test_detection3"}}, 0.0},
+  const mot::ScoreMap expected_scores{
+    {std::pair{mot::Uuid{"test_track1"}, mot::Uuid{"test_detection1"}}, 122.35757},
+    {std::pair{mot::Uuid{"test_track1"}, mot::Uuid{"test_detection2"}}, 90.688416},
+    {std::pair{mot::Uuid{"test_track2"}, mot::Uuid{"test_detection1"}}, 109.70312},
+    {std::pair{mot::Uuid{"test_track2"}, mot::Uuid{"test_detection2"}}, 95.243896},
+    {std::pair{mot::Uuid{"test_track3"}, mot::Uuid{"test_detection3"}}, 0.0},
   };
 
   EXPECT_EQ(std::size(scores), std::size(expected_scores));

--- a/test/test_scoring.cpp
+++ b/test/test_scoring.cpp
@@ -22,14 +22,14 @@
 #include <gtest/gtest.h>
 #include <units.h>
 
-#include <cooperative_perception/ctra_model.hpp>
-#include <cooperative_perception/ctrv_model.hpp>
-#include <cooperative_perception/dynamic_object.hpp>
-#include <cooperative_perception/json_parsing.hpp>
-#include <cooperative_perception/scoring.hpp>
+#include <multiple_object_tracking/ctra_model.hpp>
+#include <multiple_object_tracking/ctrv_model.hpp>
+#include <multiple_object_tracking/dynamic_object.hpp>
+#include <multiple_object_tracking/json_parsing.hpp>
+#include <multiple_object_tracking/scoring.hpp>
 #include <fstream>
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 using DetectionVariant = std::variant<cp::CtrvDetection, cp::CtraDetection>;
 using TrackVariant = std::variant<cp::CtrvTrack, cp::CtraTrack>;

--- a/test/test_temporal_alignment.cpp
+++ b/test/test_temporal_alignment.cpp
@@ -21,18 +21,18 @@
 #include <gtest/gtest.h>
 #include <units.h>
 
-#include <cooperative_perception/angle.hpp>
-#include <cooperative_perception/ctra_model.hpp>
-#include <cooperative_perception/ctrv_model.hpp>
-#include <cooperative_perception/dynamic_object.hpp>
-#include <cooperative_perception/temporal_alignment.hpp>
-#include <cooperative_perception/unscented_kalman_filter.hpp>
-#include <cooperative_perception/utils.hpp>
+#include <multiple_object_tracking/angle.hpp>
+#include <multiple_object_tracking/ctra_model.hpp>
+#include <multiple_object_tracking/ctrv_model.hpp>
+#include <multiple_object_tracking/dynamic_object.hpp>
+#include <multiple_object_tracking/temporal_alignment.hpp>
+#include <multiple_object_tracking/unscented_kalman_filter.hpp>
+#include <multiple_object_tracking/utils.hpp>
 #include <variant>
 
-#include "cooperative_perception/test/gmock_matchers.hpp"
+#include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 /**
  * Test the temporal alignment for a CTRV Detection at one second into the future

--- a/test/test_temporal_alignment.cpp
+++ b/test/test_temporal_alignment.cpp
@@ -32,7 +32,7 @@
 
 #include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
 /**
  * Test the temporal alignment for a CTRV Detection at one second into the future
@@ -41,24 +41,24 @@ TEST(TestTemporalAlignment, CtrvDetection)
 {
   using namespace units::literals;
 
-  using TestDetection = cp::Detection<cp::CtrvState, cp::CtrvStateCovariance>;
+  using TestDetection = mot::Detection<mot::CtrvState, mot::CtrvStateCovariance>;
 
   // Declaring initial state and covariance for the detection that will be temporally aligned
-  cp::CtrvStateCovariance covariance;
+  mot::CtrvStateCovariance covariance;
   covariance << 0.0043, -0.0013, 0.0030, -0.0022, -0.0020, -0.0013, 0.0077, 0.0011, 0.0071, 0.0060,
     0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.0022, 0.0071, 0.0007, 0.0098, 0.0100, -0.0020,
     0.0060, 0.0008, 0.0100, 0.0123;
 
   TestDetection detection{
     .timestamp{units::time::second_t{0}},
-    .state{cp::CtrvState{5.7441_m, 1.3800_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.3528_rad_per_s}},
+    .state{mot::CtrvState{5.7441_m, 1.3800_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.3528_rad_per_s}},
     .covariance{std::move(covariance)},
-    .uuid{cp::Uuid{""}}};
+    .uuid{mot::Uuid{""}}};
   // Expected values
-  const cp::CtrvState expected_state{
-    7.43226_m, 2.73934_m, 2.2049_mps, cp::Angle(0.8543_rad), 0.3528_rad_per_s};
+  const mot::CtrvState expected_state{
+    7.43226_m, 2.73934_m, 2.2049_mps, mot::Angle(0.8543_rad), 0.3528_rad_per_s};
 
-  cp::CtrvStateCovariance expected_covariance;
+  mot::CtrvStateCovariance expected_covariance;
   expected_covariance << 0.064633, -0.0671223, 0.00564156, -0.0462884, -0.0239845, -0.0671223,
     0.110445, 0.00623941, 0.0653499, 0.0332627, 0.00564156, 0.00623941, 0.0054, 0.0015, 0.000800001,
     -0.0462884, 0.0653499, 0.0015, 0.0421, 0.0223, -0.0239845, 0.0332627, 0.000800001, 0.0223,
@@ -72,11 +72,11 @@ TEST(TestTemporalAlignment, CtrvDetection)
   std::variant<TestDetection> detection_variant_immutable{detection};
 
   // Call the functions under test
-  cp::propagate_to_time(detection_variant, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+  mot::propagate_to_time(detection_variant, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestDetection result_detection = std::get<TestDetection>(detection_variant);
 
-  auto result_detection_variant = cp::predict_to_time(
-    detection_variant_immutable, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+  auto result_detection_variant = mot::predict_to_time(
+    detection_variant_immutable, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestDetection result_detection_immutable = std::get<TestDetection>(result_detection_variant);
 
   // Check that function returns expected value
@@ -98,23 +98,23 @@ TEST(TestTemporalAlignment, CtrvDetectionFiveSeconds)
 {
   using namespace units::literals;
 
-  using TestDetection = cp::Detection<cp::CtrvState, cp::CtrvStateCovariance>;
+  using TestDetection = mot::Detection<mot::CtrvState, mot::CtrvStateCovariance>;
 
   // Declaring initial state and covariance for the detection that will be temporally aligned
-  cp::CtrvStateCovariance covariance;
+  mot::CtrvStateCovariance covariance;
   covariance << 0.0043, -0.0013, 0.0030, -0.0022, -0.0020, -0.0013, 0.0077, 0.0011, 0.0071, 0.0060,
     0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.0022, 0.0071, 0.0007, 0.0098, 0.0100, -0.0020,
     0.0060, 0.0008, 0.0100, 0.0123;
 
   TestDetection detection{
     .timestamp{units::time::second_t{0}},
-    .state{cp::CtrvState{5.7441_m, 1.3800_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.3528_rad_per_s}},
+    .state{mot::CtrvState{5.7441_m, 1.3800_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.3528_rad_per_s}},
     .covariance{std::move(covariance)},
-    .uuid{cp::Uuid{""}}};
+    .uuid{mot::Uuid{""}}};
   // Expected values
-  const cp::CtrvState expected_state{
-    7.67240_m, 10.08887_m, 2.20490_mps, cp::Angle(2.26550_rad), 0.35280_rad_per_s};
-  cp::CtrvStateCovariance expected_covariance;
+  const mot::CtrvState expected_state{
+    7.67240_m, 10.08887_m, 2.20490_mps, mot::Angle(2.26550_rad), 0.35280_rad_per_s};
+  mot::CtrvStateCovariance expected_covariance;
   expected_covariance << 11.34872, -0.25861, -0.01521, -2.16690, -0.37041, -0.25861, 1.57984,
     0.02326, 0.01121, 0.00097, -0.01521, 0.02326, 0.00540, 0.00470, 0.00080, -2.16690, 0.01121,
     0.00470, 0.41730, 0.07150, -0.37041, 0.00097, 0.00080, 0.07150, 0.01230;
@@ -127,11 +127,11 @@ TEST(TestTemporalAlignment, CtrvDetectionFiveSeconds)
   std::variant<TestDetection> detection_variant_immutable{detection};
 
   // Call the functions under test
-  cp::propagate_to_time(detection_variant, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+  mot::propagate_to_time(detection_variant, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestDetection result_detection = std::get<TestDetection>(detection_variant);
 
-  auto result_detection_variant = cp::predict_to_time(
-    detection_variant_immutable, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+  auto result_detection_variant = mot::predict_to_time(
+    detection_variant_immutable, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestDetection result_detection_immutable = std::get<TestDetection>(result_detection_variant);
 
   // Check that function returns expected value
@@ -153,10 +153,10 @@ TEST(TestTemporalAlignment, CtraDetection)
 {
   using namespace units::literals;
 
-  using TestDetection = cp::Detection<cp::CtraState, cp::CtraStateCovariance>;
+  using TestDetection = mot::Detection<mot::CtraState, mot::CtraStateCovariance>;
 
   // Declaring initial state and covariance for the detection that will be temporally aligned
-  cp::CtraStateCovariance covariance;
+  mot::CtraStateCovariance covariance;
   covariance << 0.0043, -0.0013, 0.0030, -0.0022, -0.0020, 0.5, -0.0013, 0.0077, 0.0011, 0.0071,
     0.0060, 0.123, 0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.34, -0.0022, 0.0071, 0.0007, 0.0098,
     0.0100, 0.009, -0.0020, 0.0060, 0.0008, 0.0100, 0.0123, 0.0021, 0.5, 0.123, -0.34, 0.009,
@@ -164,14 +164,14 @@ TEST(TestTemporalAlignment, CtraDetection)
 
   TestDetection detection{
     .timestamp{units::time::second_t{0}},
-    .state{cp::CtraState{
-      5.7441_m, 1.3800_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.3528_rad_per_s, 1_mps_sq}},
+    .state{mot::CtraState{
+      5.7441_m, 1.3800_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.3528_rad_per_s, 1_mps_sq}},
     .covariance{std::move(covariance)},
-    .uuid{cp::Uuid{""}}};
+    .uuid{mot::Uuid{""}}};
   // Expected values
-  const cp::CtraState expected_state{
-    7.79608_m, 3.06936_m, 3.20490_mps, cp::Angle(0.85430_rad), 0.35280_rad_per_s, 1.00000_mps_sq};
-  cp::CtraStateCovariance expected_covariance;
+  const mot::CtraState expected_state{
+    7.79608_m, 3.06936_m, 3.20490_mps, mot::Angle(0.85430_rad), 0.35280_rad_per_s, 1.00000_mps_sq};
+  mot::CtraStateCovariance expected_covariance;
   expected_covariance << 39.64152, 34.73882, 106.16206, -0.06633, -0.03572, 106.28492, 34.73882,
     32.49688, 95.98216, 0.06945, 0.03433, 96.09180, 106.16206, 95.98216, 288.55997, 0.01260,
     0.00290, 288.89456, -0.06633, 0.06945, 0.01260, 0.04210, 0.02230, 0.01110, -0.03572, 0.03433,
@@ -185,11 +185,11 @@ TEST(TestTemporalAlignment, CtraDetection)
   std::variant<TestDetection> detection_variant_immutable{detection};
 
   // Call the functions under test
-  cp::propagate_to_time(detection_variant, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+  mot::propagate_to_time(detection_variant, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestDetection result_detection = std::get<TestDetection>(detection_variant);
 
-  auto result_detection_variant = cp::predict_to_time(
-    detection_variant_immutable, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+  auto result_detection_variant = mot::predict_to_time(
+    detection_variant_immutable, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestDetection result_detection_immutable = std::get<TestDetection>(result_detection_variant);
 
   // Check that function returns expected value
@@ -211,10 +211,10 @@ TEST(TestTemporalAlignment, CtraDetectionFiveSeconds)
 {
   using namespace units::literals;
 
-  using TestDetection = cp::Detection<cp::CtraState, cp::CtraStateCovariance>;
+  using TestDetection = mot::Detection<mot::CtraState, mot::CtraStateCovariance>;
 
   // Declaring initial state and covariance for the detection that will be temporally aligned
-  cp::CtraStateCovariance covariance;
+  mot::CtraStateCovariance covariance;
   covariance << 0.0043, -0.0013, 0.0030, -0.0022, -0.0020, 0.5, -0.0013, 0.0077, 0.0011, 0.0071,
     0.0060, 0.123, 0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.34, -0.0022, 0.0071, 0.0007, 0.0098,
     0.0100, 0.009, -0.0020, 0.0060, 0.0008, 0.0100, 0.0123, 0.0021, 0.5, 0.123, -0.34, 0.009,
@@ -222,14 +222,14 @@ TEST(TestTemporalAlignment, CtraDetectionFiveSeconds)
 
   TestDetection detection{
     .timestamp{units::time::second_t{0}},
-    .state{cp::CtraState{
-      5.7441_m, 1.3800_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.3528_rad_per_s, 1_mps_sq}},
+    .state{mot::CtraState{
+      5.7441_m, 1.3800_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.3528_rad_per_s, 1_mps_sq}},
     .covariance{std::move(covariance)},
-    .uuid{cp::Uuid{""}}};
+    .uuid{mot::Uuid{""}}};
   // Expected values
-  const cp::CtraState expected_state{
-    8.92670_m, 21.12001_m, 7.20490_mps, cp::Angle(2.26550_rad), 0.35280_rad_per_s, 1.00000_mps_sq};
-  cp::CtraStateCovariance expected_covariance;
+  const mot::CtraState expected_state{
+    8.92670_m, 21.12001_m, 7.20490_mps, mot::Angle(2.26550_rad), 0.35280_rad_per_s, 1.00000_mps_sq};
+  mot::CtraStateCovariance expected_covariance;
   expected_covariance << 3272.17554, -2753.25513, -1620.65405, -2.53488, -0.43595, -324.23853,
     -2753.25513, 34524.34766, 15688.62207, -8.90359, -1.52473, 3138.58984, -1620.65405, 15688.62207,
     7227.46826, 0.10220, 0.01130, 1445.83264, -2.53488, -8.90359, 0.10220, 0.41730, 0.07150,
@@ -244,11 +244,11 @@ TEST(TestTemporalAlignment, CtraDetectionFiveSeconds)
   std::variant<TestDetection> detection_variant_immutable{detection};
 
   // Call the functions under test
-  cp::propagate_to_time(detection_variant, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+  mot::propagate_to_time(detection_variant, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestDetection result_detection = std::get<TestDetection>(detection_variant);
 
-  auto result_detection_variant = cp::predict_to_time(
-    detection_variant_immutable, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+  auto result_detection_variant = mot::predict_to_time(
+    detection_variant_immutable, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestDetection result_detection_immutable = std::get<TestDetection>(result_detection_variant);
 
   // Check that function returns expected value
@@ -270,24 +270,24 @@ TEST(TestTemporalAlignment, CtrvTrack)
 {
   using namespace units::literals;
 
-  using TestTrack = cp::Track<cp::CtrvState, cp::CtrvStateCovariance>;
+  using TestTrack = mot::Track<mot::CtrvState, mot::CtrvStateCovariance>;
 
   // Declaring initial state and covariance for the track that will be temporally aligned
-  cp::CtrvStateCovariance covariance;
+  mot::CtrvStateCovariance covariance;
   covariance << 0.0043, -0.0013, 0.0030, -0.0022, -0.0020, -0.0013, 0.0077, 0.0011, 0.0071, 0.0060,
     0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.0022, 0.0071, 0.0007, 0.0098, 0.0100, -0.0020,
     0.0060, 0.0008, 0.0100, 0.0123;
 
   TestTrack track{
     .timestamp{units::time::second_t{0}},
-    .state{cp::CtrvState{5.7441_m, 1.3800_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.3528_rad_per_s}},
+    .state{mot::CtrvState{5.7441_m, 1.3800_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.3528_rad_per_s}},
     .covariance{std::move(covariance)},
-    .uuid{cp::Uuid{""}}};
+    .uuid{mot::Uuid{""}}};
   // Expected values
-  const cp::CtrvState expected_state{
-    7.43226_m, 2.73934_m, 2.2049_mps, cp::Angle(0.8543_rad), 0.3528_rad_per_s};
+  const mot::CtrvState expected_state{
+    7.43226_m, 2.73934_m, 2.2049_mps, mot::Angle(0.8543_rad), 0.3528_rad_per_s};
 
-  cp::CtrvStateCovariance expected_covariance;
+  mot::CtrvStateCovariance expected_covariance;
   expected_covariance << 0.064633, -0.0671223, 0.00564156, -0.0462884, -0.0239845, -0.0671223,
     0.110445, 0.00623941, 0.0653499, 0.0332627, 0.00564156, 0.00623941, 0.0054, 0.0015, 0.000800001,
     -0.0462884, 0.0653499, 0.0015, 0.0421, 0.0223, -0.0239845, 0.0332627, 0.000800001, 0.0223,
@@ -301,11 +301,11 @@ TEST(TestTemporalAlignment, CtrvTrack)
   std::variant<TestTrack> track_variant_immutable{track};
 
   // Call the functions under test
-  cp::propagate_to_time(track_variant, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+  mot::propagate_to_time(track_variant, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestTrack result_track = std::get<TestTrack>(track_variant);
 
   auto result_track_variant =
-    cp::predict_to_time(track_variant_immutable, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+    mot::predict_to_time(track_variant_immutable, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestTrack result_track_immutable = std::get<TestTrack>(result_track_variant);
 
   // Check that function returns expected value
@@ -327,10 +327,10 @@ TEST(TestTemporalAlignment, CtraTrack)
 {
   using namespace units::literals;
 
-  using TestTrack = cp::Track<cp::CtraState, cp::CtraStateCovariance>;
+  using TestTrack = mot::Track<mot::CtraState, mot::CtraStateCovariance>;
 
   // Declaring initial state and covariance for the track that will be temporally aligned
-  cp::CtraStateCovariance covariance;
+  mot::CtraStateCovariance covariance;
   covariance << 0.0043, -0.0013, 0.0030, -0.0022, -0.0020, 0.5, -0.0013, 0.0077, 0.0011, 0.0071,
     0.0060, 0.123, 0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.34, -0.0022, 0.0071, 0.0007, 0.0098,
     0.0100, 0.009, -0.0020, 0.0060, 0.0008, 0.0100, 0.0123, 0.0021, 0.5, 0.123, -0.34, 0.009,
@@ -338,14 +338,14 @@ TEST(TestTemporalAlignment, CtraTrack)
 
   TestTrack track{
     .timestamp{units::time::second_t{0}},
-    .state{cp::CtraState{
-      5.7441_m, 1.3800_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.3528_rad_per_s, 1_mps_sq}},
+    .state{mot::CtraState{
+      5.7441_m, 1.3800_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.3528_rad_per_s, 1_mps_sq}},
     .covariance{std::move(covariance)},
-    .uuid{cp::Uuid{""}}};
+    .uuid{mot::Uuid{""}}};
   // Expected values
-  const cp::CtraState expected_state{
-    7.79608_m, 3.06936_m, 3.20490_mps, cp::Angle(0.85430_rad), 0.35280_rad_per_s, 1.00000_mps_sq};
-  cp::CtraStateCovariance expected_covariance;
+  const mot::CtraState expected_state{
+    7.79608_m, 3.06936_m, 3.20490_mps, mot::Angle(0.85430_rad), 0.35280_rad_per_s, 1.00000_mps_sq};
+  mot::CtraStateCovariance expected_covariance;
   expected_covariance << 39.64152, 34.73882, 106.16206, -0.06633, -0.03572, 106.28492, 34.73882,
     32.49688, 95.98216, 0.06945, 0.03433, 96.09180, 106.16206, 95.98216, 288.55997, 0.01260,
     0.00290, 288.89456, -0.06633, 0.06945, 0.01260, 0.04210, 0.02230, 0.01110, -0.03572, 0.03433,
@@ -359,11 +359,11 @@ TEST(TestTemporalAlignment, CtraTrack)
   std::variant<TestTrack> track_variant_immutable{track};
 
   // Call the functions under test
-  cp::propagate_to_time(track_variant, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+  mot::propagate_to_time(track_variant, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestTrack result_track = std::get<TestTrack>(track_variant);
 
   auto result_track_variant =
-    cp::predict_to_time(track_variant_immutable, time_step, cp::UnscentedTransform{1.0, 2.0, 1.0});
+    mot::predict_to_time(track_variant_immutable, time_step, mot::UnscentedTransform{1.0, 2.0, 1.0});
   TestTrack result_track_immutable = std::get<TestTrack>(result_track_variant);
 
   // Check that function returns expected value

--- a/test/test_track_management.cpp
+++ b/test/test_track_management.cpp
@@ -21,18 +21,18 @@
 #include <multiple_object_tracking/track_management.hpp>
 #include <multiple_object_tracking/uuid.hpp>
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
 TEST(TestTrackManagement, Simple)
 {
-  cp::FixedThresholdTrackManager<cp::CtrvTrack> track_manager{
-    cp::PromotionThreshold{3}, cp::RemovalThreshold{1}};
+  mot::FixedThresholdTrackManager<mot::CtrvTrack> track_manager{
+    mot::PromotionThreshold{3}, mot::RemovalThreshold{1}};
 
-  cp::CtrvTrack track;
-  track.uuid = cp::Uuid{"test_track"};
+  mot::CtrvTrack track;
+  track.uuid = mot::Uuid{"test_track"};
 
-  cp::AssociationMap association_map;
-  association_map[cp::Uuid{"test_track"}].push_back(cp::Uuid{"test_detection"});
+  mot::AssociationMap association_map;
+  association_map[mot::Uuid{"test_track"}].push_back(mot::Uuid{"test_detection"});
 
   track_manager.add_tentative_track(track);
 
@@ -52,14 +52,14 @@ TEST(TestTrackManagement, Simple)
   EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 1U);
   EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
 
-  track_manager.update_track_lists(cp::AssociationMap{});
+  track_manager.update_track_lists(mot::AssociationMap{});
 
   EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 1U);
   EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
   EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
 
-  track_manager.update_track_lists(cp::AssociationMap{});
-  track_manager.update_track_lists(cp::AssociationMap{});
+  track_manager.update_track_lists(mot::AssociationMap{});
+  track_manager.update_track_lists(mot::AssociationMap{});
 
   EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U);
   EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
@@ -68,23 +68,23 @@ TEST(TestTrackManagement, Simple)
 
 TEST(TestTrackManagement, Getters)
 {
-  const cp::FixedThresholdTrackManager<cp::CtrvTrack> track_manager{
-    cp::PromotionThreshold{3}, cp::RemovalThreshold{1}};
+  const mot::FixedThresholdTrackManager<mot::CtrvTrack> track_manager{
+    mot::PromotionThreshold{3}, mot::RemovalThreshold{1}};
 
-  EXPECT_EQ(track_manager.get_promotion_threshold().value, cp::PromotionThreshold{3U}.value);
-  EXPECT_EQ(track_manager.get_removal_threshold().value, cp::RemovalThreshold{1U}.value);
+  EXPECT_EQ(track_manager.get_promotion_threshold().value, mot::PromotionThreshold{3U}.value);
+  EXPECT_EQ(track_manager.get_removal_threshold().value, mot::RemovalThreshold{1U}.value);
 }
 
 TEST(TestTrackManagement, Setters)
 {
-  cp::FixedThresholdTrackManager<cp::CtrvTrack> track_manager{
-    cp::PromotionThreshold{3}, cp::RemovalThreshold{1}};
+  mot::FixedThresholdTrackManager<mot::CtrvTrack> track_manager{
+    mot::PromotionThreshold{3}, mot::RemovalThreshold{1}};
 
-  cp::CtrvTrack track;
-  track.uuid = cp::Uuid{"test_track"};
+  mot::CtrvTrack track;
+  track.uuid = mot::Uuid{"test_track"};
 
-  cp::AssociationMap association_map;
-  association_map[cp::Uuid{"test_track"}].push_back(cp::Uuid{"test_detection"});
+  mot::AssociationMap association_map;
+  association_map[mot::Uuid{"test_track"}].push_back(mot::Uuid{"test_detection"});
 
   track_manager.add_tentative_track(track);
 
@@ -100,19 +100,19 @@ TEST(TestTrackManagement, Setters)
 
   track_manager.update_track_lists(association_map);
 
-  track_manager.set_promotion_threshold_and_update(cp::PromotionThreshold{1U});
+  track_manager.set_promotion_threshold_and_update(mot::PromotionThreshold{1U});
 
   EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U);
   EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 1U);
   EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
 
-  track_manager.set_promotion_threshold_and_update(cp::PromotionThreshold{10U});
+  track_manager.set_promotion_threshold_and_update(mot::PromotionThreshold{10U});
 
   EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 1U);
   EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
   EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
 
-  track_manager.set_removal_threshold_and_update(cp::RemovalThreshold{5U});
+  track_manager.set_removal_threshold_and_update(mot::RemovalThreshold{5U});
 
   EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U);
   EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);

--- a/test/test_track_management.cpp
+++ b/test/test_track_management.cpp
@@ -17,11 +17,11 @@
 #include <gtest/gtest.h>
 #include <units.h>
 
-#include <cooperative_perception/ctrv_model.hpp>
-#include <cooperative_perception/track_management.hpp>
-#include <cooperative_perception/uuid.hpp>
+#include <multiple_object_tracking/ctrv_model.hpp>
+#include <multiple_object_tracking/track_management.hpp>
+#include <multiple_object_tracking/uuid.hpp>
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 TEST(TestTrackManagement, Simple)
 {

--- a/test/test_track_matching.cpp
+++ b/test/test_track_matching.cpp
@@ -22,11 +22,11 @@
 #include <dlib/optimization/max_cost_assignment.h>
 #include <gtest/gtest.h>
 
-#include <cooperative_perception/dynamic_object.hpp>
-#include <cooperative_perception/scoring.hpp>
-#include <cooperative_perception/track_matching.hpp>
+#include <multiple_object_tracking/dynamic_object.hpp>
+#include <multiple_object_tracking/scoring.hpp>
+#include <multiple_object_tracking/track_matching.hpp>
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 /**
  * Test dlib library installation using example from library

--- a/test/test_track_matching.cpp
+++ b/test/test_track_matching.cpp
@@ -26,7 +26,7 @@
 #include <multiple_object_tracking/scoring.hpp>
 #include <multiple_object_tracking/track_matching.hpp>
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
 /**
  * Test dlib library installation using example from library
@@ -66,24 +66,24 @@ TEST(TestTrackMatching, VerifyLibraryInstallation)
  */
 TEST(TestTrackMatching, GnnAssociator)
 {
-  cp::ScoreMap scores{
-    {{cp::Uuid{"track1"}, cp::Uuid{"detection1"}}, 10},
-    {{cp::Uuid{"track1"}, cp::Uuid{"detection2"}}, 2.0},
-    {{cp::Uuid{"track1"}, cp::Uuid{"detection3"}}, 1.0},
-    {{cp::Uuid{"track2"}, cp::Uuid{"detection1"}}, 2.0},
-    {{cp::Uuid{"track2"}, cp::Uuid{"detection2"}}, 1.0},
-    {{cp::Uuid{"track2"}, cp::Uuid{"detection3"}}, 10.0},
-    {{cp::Uuid{"track3"}, cp::Uuid{"detection1"}}, 3.0},
-    {{cp::Uuid{"track3"}, cp::Uuid{"detection2"}}, 10.0},
-    {{cp::Uuid{"track3"}, cp::Uuid{"detection3"}}, 5.0}};
+  mot::ScoreMap scores{
+    {{mot::Uuid{"track1"}, mot::Uuid{"detection1"}}, 10},
+    {{mot::Uuid{"track1"}, mot::Uuid{"detection2"}}, 2.0},
+    {{mot::Uuid{"track1"}, mot::Uuid{"detection3"}}, 1.0},
+    {{mot::Uuid{"track2"}, mot::Uuid{"detection1"}}, 2.0},
+    {{mot::Uuid{"track2"}, mot::Uuid{"detection2"}}, 1.0},
+    {{mot::Uuid{"track2"}, mot::Uuid{"detection3"}}, 10.0},
+    {{mot::Uuid{"track3"}, mot::Uuid{"detection1"}}, 3.0},
+    {{mot::Uuid{"track3"}, mot::Uuid{"detection2"}}, 10.0},
+    {{mot::Uuid{"track3"}, mot::Uuid{"detection3"}}, 5.0}};
 
-  cp::AssociationMap expected_associations{
-    {cp::Uuid{"track1"}, {cp::Uuid{"detection3"}}},
-    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
-    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
+  mot::AssociationMap expected_associations{
+    {mot::Uuid{"track1"}, {mot::Uuid{"detection3"}}},
+    {mot::Uuid{"track2"}, {mot::Uuid{"detection2"}}},
+    {mot::Uuid{"track3"}, {mot::Uuid{"detection1"}}}};
 
   auto result_associations =
-    cp::associate_detections_to_tracks(scores, cp::gnn_association_visitor);
+    mot::associate_detections_to_tracks(scores, mot::gnn_association_visitor);
 
   EXPECT_EQ(std::size(expected_associations), std::size(result_associations));
 
@@ -115,18 +115,18 @@ TEST(TestTrackMatching, GnnAssociator)
  */
 TEST(TestTrackMatching, GnnAssociatorWithGatedScores)
 {
-  cp::ScoreMap scores{
-    {{cp::Uuid{"track1"}, cp::Uuid{"detection3"}}, 1.0},
-    {{cp::Uuid{"track2"}, cp::Uuid{"detection2"}}, 1.0},
-    {{cp::Uuid{"track3"}, cp::Uuid{"detection1"}}, 1.0}};
+  mot::ScoreMap scores{
+    {{mot::Uuid{"track1"}, mot::Uuid{"detection3"}}, 1.0},
+    {{mot::Uuid{"track2"}, mot::Uuid{"detection2"}}, 1.0},
+    {{mot::Uuid{"track3"}, mot::Uuid{"detection1"}}, 1.0}};
 
-  cp::AssociationMap expected_associations{
-    {cp::Uuid{"track1"}, {cp::Uuid{"detection3"}}},
-    {cp::Uuid{"track2"}, {cp::Uuid{"detection2"}}},
-    {cp::Uuid{"track3"}, {cp::Uuid{"detection1"}}}};
+  mot::AssociationMap expected_associations{
+    {mot::Uuid{"track1"}, {mot::Uuid{"detection3"}}},
+    {mot::Uuid{"track2"}, {mot::Uuid{"detection2"}}},
+    {mot::Uuid{"track3"}, {mot::Uuid{"detection1"}}}};
 
   auto result_associations =
-    cp::associate_detections_to_tracks(scores, cp::gnn_association_visitor);
+    mot::associate_detections_to_tracks(scores, mot::gnn_association_visitor);
 
   EXPECT_EQ(std::size(expected_associations), std::size(result_associations));
 
@@ -155,14 +155,14 @@ TEST(TestTrackMatching, GnnAssociatorWithGatedScores)
 
 TEST(TestTrackMatching, GnnAssociatorMoreDetectionsThanTracks)
 {
-  const cp::ScoreMap scores{
-    {{cp::Uuid{"track1"}, cp::Uuid{"detection1"}}, 10},
-    {{cp::Uuid{"track1"}, cp::Uuid{"detection2"}}, 2.0}};
+  const mot::ScoreMap scores{
+    {{mot::Uuid{"track1"}, mot::Uuid{"detection1"}}, 10},
+    {{mot::Uuid{"track1"}, mot::Uuid{"detection2"}}, 2.0}};
 
-  const cp::AssociationMap expected_associations{{cp::Uuid{"track1"}, {cp::Uuid{"detection2"}}}};
+  const mot::AssociationMap expected_associations{{mot::Uuid{"track1"}, {mot::Uuid{"detection2"}}}};
 
   const auto result_associations =
-    cp::associate_detections_to_tracks(scores, cp::gnn_association_visitor);
+    mot::associate_detections_to_tracks(scores, mot::gnn_association_visitor);
 
   EXPECT_EQ(std::size(expected_associations), std::size(result_associations));
 

--- a/test/test_unscented_kalman_filter.cpp
+++ b/test/test_unscented_kalman_filter.cpp
@@ -21,15 +21,15 @@
 #include <gtest/gtest.h>
 #include <units.h>
 
-#include <cooperative_perception/angle.hpp>
-#include <cooperative_perception/ctra_model.hpp>
-#include <cooperative_perception/ctrv_model.hpp>
-#include <cooperative_perception/unscented_kalman_filter.hpp>
-#include <cooperative_perception/utils.hpp>
+#include <multiple_object_tracking/angle.hpp>
+#include <multiple_object_tracking/ctra_model.hpp>
+#include <multiple_object_tracking/ctrv_model.hpp>
+#include <multiple_object_tracking/unscented_kalman_filter.hpp>
+#include <multiple_object_tracking/utils.hpp>
 
-#include "cooperative_perception/test/gmock_matchers.hpp"
+#include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 /**
  * Test the ComputeUnscentedTransform function given a CTRV state, covariance and time step

--- a/test/test_unscented_kalman_filter.cpp
+++ b/test/test_unscented_kalman_filter.cpp
@@ -29,7 +29,7 @@
 
 #include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
 /**
  * Test the ComputeUnscentedTransform function given a CTRV state, covariance and time step
@@ -39,16 +39,16 @@ TEST(TestUnscentedKalmanFilter, CtrvPrediction)
   using namespace units::literals;
 
   // Declaring Initial state and covariance
-  const cp::CtrvState state{
-    5.7441_m, 1.3800_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.3528_rad_per_s};
-  cp::CtrvStateCovariance covariance;
+  const mot::CtrvState state{
+    5.7441_m, 1.3800_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.3528_rad_per_s};
+  mot::CtrvStateCovariance covariance;
   covariance << 0.0043, -0.0013, 0.0030, -0.0022, -0.0020, -0.0013, 0.0077, 0.0011, 0.0071, 0.0060,
     0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.0022, 0.0071, 0.0007, 0.0098, 0.0100, -0.0020,
     0.0060, 0.0008, 0.0100, 0.0123;
   // Expected values
-  const cp::CtrvState expected_state{
-    7.43224_m, 2.73933_m, 2.2049_mps, cp::Angle(0.8543_rad), 0.3528_rad_per_s};
-  cp::CtrvStateCovariance expected_covariance;
+  const mot::CtrvState expected_state{
+    7.43224_m, 2.73933_m, 2.2049_mps, mot::Angle(0.8543_rad), 0.3528_rad_per_s};
+  mot::CtrvStateCovariance expected_covariance;
   expected_covariance << 0.0650073, -0.0670999, 0.00564003, -0.0463523, -0.0240175, -0.0670999,
     0.11094, 0.00625031, 0.0654438, 0.0333096, 0.00564003, 0.00625031, 0.0054, 0.0015, 0.000800002,
     -0.0463523, 0.0654438, 0.0015, 0.0421, 0.0223, -0.0240175, 0.0333096, 0.000800002, 0.0223,
@@ -61,9 +61,9 @@ TEST(TestUnscentedKalmanFilter, CtrvPrediction)
   const auto time_step{1.0_s};
 
   const auto transform_res{
-    cp::unscented_kalman_filter_predict(state, covariance, time_step, alpha, beta, kappa)};
-  cp::CtrvState result_state{std::get<0>(transform_res)};
-  cp::CtrvStateCovariance result_covariance{std::get<1>(transform_res)};
+    mot::unscented_kalman_filter_predict(state, covariance, time_step, alpha, beta, kappa)};
+  mot::CtrvState result_state{std::get<0>(transform_res)};
+  mot::CtrvStateCovariance result_covariance{std::get<1>(transform_res)};
 
   EXPECT_THAT(result_state, CtrvStateNear(expected_state, 1e-4));
   EXPECT_THAT(result_covariance, EigenMatrixNear(expected_covariance, 1e-4));
@@ -74,18 +74,18 @@ TEST(TestUnscentedKalmanFilter, CtraPrediction)
   using namespace units::literals;
 
   // Declaring Initial state and covariance
-  const cp::CtraState state{5.7441_m,         1.3800_m, 2.2049_mps, cp::Angle(0.5015_rad),
+  const mot::CtraState state{5.7441_m,         1.3800_m, 2.2049_mps, mot::Angle(0.5015_rad),
                             0.3528_rad_per_s, 1_mps_sq};
-  cp::CtraStateCovariance covariance;
+  mot::CtraStateCovariance covariance;
   covariance << 0.0043, -0.0013, 0.0030, -0.0022, -0.0020, 0.5, -0.0013, 0.0077, 0.0011, 0.0071,
     0.0060, 0.123, 0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.34, -0.0022, 0.0071, 0.0007, 0.0098,
     0.0100, 0.009, -0.0020, 0.0060, 0.0008, 0.0100, 0.0123, 0.0021, 0.5, 0.123, -0.34, 0.009,
     0.0021, -0.8701;
 
   // Expected values
-  const cp::CtraState expected_state{
-    7.79562_m, 3.06979_m, 3.20490_mps, cp::Angle(0.85430_rad), 0.35280_rad_per_s, 1.00000_mps_sq};
-  cp::CtraStateCovariance expected_covariance;
+  const mot::CtraState expected_state{
+    7.79562_m, 3.06979_m, 3.20490_mps, mot::Angle(0.85430_rad), 0.35280_rad_per_s, 1.00000_mps_sq};
+  mot::CtraStateCovariance expected_covariance;
   expected_covariance << 39.64316, 34.85464, 106.24644, -0.06485, -0.03496, 106.36900, 34.85464,
     32.50103, 96.06596, 0.07105, 0.03515, 96.17529, 106.24644, 96.06596, 288.55994, 0.01260,
     0.00290, 288.89456, -0.06485, 0.07105, 0.01260, 0.04210, 0.02230, 0.01110, -0.03496, 0.03515,
@@ -98,9 +98,9 @@ TEST(TestUnscentedKalmanFilter, CtraPrediction)
   const auto time_step{1.0_s};
 
   const auto transform_res{
-    cp::unscented_kalman_filter_predict(state, covariance, time_step, alpha, beta, kappa)};
-  cp::CtraState result_state{std::get<0>(transform_res)};
-  cp::CtraStateCovariance result_covariance{std::get<1>(transform_res)};
+    mot::unscented_kalman_filter_predict(state, covariance, time_step, alpha, beta, kappa)};
+  mot::CtraState result_state{std::get<0>(transform_res)};
+  mot::CtraStateCovariance result_covariance{std::get<1>(transform_res)};
 
   EXPECT_THAT(result_state, CtraStateNear(expected_state, 1e-4));
   EXPECT_THAT(result_covariance, EigenMatrixNear(expected_covariance, 1e-4));

--- a/test/test_unscented_transform.cpp
+++ b/test/test_unscented_transform.cpp
@@ -21,14 +21,14 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <cooperative_perception/angle.hpp>
-#include <cooperative_perception/ctrv_model.hpp>
-#include <cooperative_perception/unscented_transform.hpp>
-#include <cooperative_perception/utils.hpp>
+#include <multiple_object_tracking/angle.hpp>
+#include <multiple_object_tracking/ctrv_model.hpp>
+#include <multiple_object_tracking/unscented_transform.hpp>
+#include <multiple_object_tracking/utils.hpp>
 
-#include "cooperative_perception/test/gmock_matchers.hpp"
+#include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = cooperative_perception;
+namespace cp = multiple_object_tracking;
 
 /**
  * Test the generate_sigma_points function

--- a/test/test_unscented_transform.cpp
+++ b/test/test_unscented_transform.cpp
@@ -28,7 +28,7 @@
 
 #include "multiple_object_tracking/test/gmock_matchers.hpp"
 
-namespace cp = multiple_object_tracking;
+namespace mot = multiple_object_tracking;
 
 /**
  * Test the generate_sigma_points function
@@ -36,35 +36,35 @@ namespace cp = multiple_object_tracking;
 TEST(TestUnscentedTransform, GenerateSigmaPoints)
 {
   using namespace units::literals;
-  const cp::CtrvState state{
-    5.7441_m, 1.3800_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.3528_rad_per_s};
-  cp::CtrvStateCovariance covariance;
+  const mot::CtrvState state{
+    5.7441_m, 1.3800_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.3528_rad_per_s};
+  mot::CtrvStateCovariance covariance;
   covariance << 0.0043, -0.0013, 0.0030, -0.0022, -0.0020, -0.0013, 0.0077, 0.0011, 0.0071, 0.0060,
     0.0030, 0.0011, 0.0054, 0.0007, 0.0008, -0.0022, 0.0071, 0.0007, 0.0098, 0.0100, -0.0020,
     0.0060, 0.0008, 0.0100, 0.0123;
   const auto alpha{1.0};
   const auto kappa{1.0};
-  const auto lambda{cp::generate_lambda(state.kNumVars, alpha, kappa)};
-  const auto sigma_points{cp::generate_sigma_points(state, covariance, lambda)};
+  const auto lambda{mot::generate_lambda(state.kNumVars, alpha, kappa)};
+  const auto sigma_points{mot::generate_sigma_points(state, covariance, lambda)};
 
-  const std::vector<cp::CtrvState> expected_sigma_points{
-    cp::CtrvState{
-      5.90472378_m, 1.33143932_m, 2.31696311_mps, cp::Angle(0.41932039_rad), 0.27809126_rad_per_s},
-    cp::CtrvState{
-      5.58347622_m, 1.42856068_m, 2.09283689_mps, cp::Angle(0.58367961_rad), 0.42750874_rad_per_s},
-    cp::CtrvState{
-      5.7441_m, 1.58938448_m, 2.26241076_mps, cp::Angle(0.68589429_rad), 0.50740598_rad_per_s},
-    cp::CtrvState{
-      5.7441_m, 1.17061552_m, 2.14738924_mps, cp::Angle(0.31710571_rad), 0.19819402_rad_per_s},
-    cp::CtrvState{
-      5.7441_m, 1.38_m, 2.33348605_mps, cp::Angle(0.52331144_rad), 0.38608966_rad_per_s},
-    cp::CtrvState{
-      5.7441_m, 1.38_m, 2.07631395_mps, cp::Angle(0.47968856_rad), 0.31951034_rad_per_s},
-    cp::CtrvState{5.7441_m, 1.38_m, 2.2049_mps, cp::Angle(0.63405006_rad), 0.53858573_rad_per_s},
-    cp::CtrvState{5.7441_m, 1.38_m, 2.2049_mps, cp::Angle(0.36894994_rad), 0.16701427_rad_per_s},
-    cp::CtrvState{5.7441_m, 1.38_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.44602584_rad_per_s},
-    cp::CtrvState{5.7441_m, 1.38_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.25957416_rad_per_s},
-    cp::CtrvState{5.7441_m, 1.38_m, 2.2049_mps, cp::Angle(0.5015_rad), 0.3528_rad_per_s}
+  const std::vector<mot::CtrvState> expected_sigma_points{
+    mot::CtrvState{
+      5.90472378_m, 1.33143932_m, 2.31696311_mps, mot::Angle(0.41932039_rad), 0.27809126_rad_per_s},
+    mot::CtrvState{
+      5.58347622_m, 1.42856068_m, 2.09283689_mps, mot::Angle(0.58367961_rad), 0.42750874_rad_per_s},
+    mot::CtrvState{
+      5.7441_m, 1.58938448_m, 2.26241076_mps, mot::Angle(0.68589429_rad), 0.50740598_rad_per_s},
+    mot::CtrvState{
+      5.7441_m, 1.17061552_m, 2.14738924_mps, mot::Angle(0.31710571_rad), 0.19819402_rad_per_s},
+    mot::CtrvState{
+      5.7441_m, 1.38_m, 2.33348605_mps, mot::Angle(0.52331144_rad), 0.38608966_rad_per_s},
+    mot::CtrvState{
+      5.7441_m, 1.38_m, 2.07631395_mps, mot::Angle(0.47968856_rad), 0.31951034_rad_per_s},
+    mot::CtrvState{5.7441_m, 1.38_m, 2.2049_mps, mot::Angle(0.63405006_rad), 0.53858573_rad_per_s},
+    mot::CtrvState{5.7441_m, 1.38_m, 2.2049_mps, mot::Angle(0.36894994_rad), 0.16701427_rad_per_s},
+    mot::CtrvState{5.7441_m, 1.38_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.44602584_rad_per_s},
+    mot::CtrvState{5.7441_m, 1.38_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.25957416_rad_per_s},
+    mot::CtrvState{5.7441_m, 1.38_m, 2.2049_mps, mot::Angle(0.5015_rad), 0.3528_rad_per_s}
 
   };
 
@@ -93,10 +93,10 @@ TEST(TestUnscentedTransform, GenerateWeights)
   const auto alpha{1.0};
   const auto beta{2.0};
   const auto kappa{1.0};
-  const auto lambda{cp::generate_lambda(n, alpha, kappa)};
+  const auto lambda{mot::generate_lambda(n, alpha, kappa)};
 
   // Call the function under test
-  const auto [Wm, Wc] = cp::generate_weights(n, alpha, beta, lambda);
+  const auto [Wm, Wc] = mot::generate_weights(n, alpha, beta, lambda);
 
   // Define the expected output
   Eigen::VectorXf expected_Wm(11);
@@ -143,7 +143,7 @@ TEST(TestUnscentedTransform, ComputeUnscentedTransformPureEigen)
     0.006, 0.003, 0.0011, 0.0054, 0.0007, 0.0008, -0.0022, 0.0071, 0.0007, 0.0098, 0.01, -0.002,
     0.006, 0.0008, 0.01, 0.0123;
 
-  const auto transform_res{cp::compute_unscented_transform(sigma_points, Wm, Wc)};
+  const auto transform_res{mot::compute_unscented_transform(sigma_points, Wm, Wc)};
   const auto result_state{std::get<0>(transform_res)};
   const auto result_covariance{std::get<1>(transform_res)};
 


### PR DESCRIPTION
# PR Details
## Description

This PR replaces the `cooperative_perception_core` references with `multiple_object_tracking`. 

## Related GitHub Issue

Closes #80 

## Related Jira Key

Closes [CDAR-447](https://usdot-carma.atlassian.net/browse/CDAR-447)

## Motivation and Context

The `cooperative_perception_core` name was misleading because the library does not do cooperative perception _per se_. It's a multiple object tracking library that can be deployed to facilitate cooperative perception.

## How Has This Been Tested?

Name changes. No new tests.

## Types of changes

- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.


[CDAR-447]: https://usdot-carma.atlassian.net/browse/CDAR-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ