### PR TITLE
Update `multiple_object_trackingLibrary` name

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,19 +14,19 @@
 
 # Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
 
-add_library(multiple_object_trackingLibrary
+add_library(multiple_object_tracking
   ctrv_model.cpp
   ctra_model.cpp
 )
 
-add_library(multiple_object_tracking::multiple_object_tracking ALIAS multiple_object_trackingLibrary)
+add_library(multiple_object_tracking::multiple_object_tracking ALIAS multiple_object_tracking)
 
-target_include_directories(multiple_object_trackingLibrary
+target_include_directories(multiple_object_tracking
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
 
-target_link_libraries(multiple_object_trackingLibrary
+target_link_libraries(multiple_object_tracking
   PUBLIC
     Boost::container
     Eigen3::Eigen
@@ -35,13 +35,13 @@ target_link_libraries(multiple_object_trackingLibrary
     nlohmann_json::nlohmann_json
 )
 
-set_target_properties(multiple_object_trackingLibrary PROPERTIES
+set_target_properties(multiple_object_tracking PROPERTIES
   POSITION_INDEPENDENT_CODE TRUE
 )
 
 include(GNUInstallDirs)
 
-install(TARGETS multiple_object_trackingLibrary
+install(TARGETS multiple_object_tracking
   EXPORT multiple_object_trackingTargets
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
# PR Details
## Description

To avoid a clunky user experience when linking against this library, the `multiple_object_trackingLibrary` target name was renamed to `multiple_object_tracking`.

## Related GitHub Issue

Closes #108 

## Related Jira Key

Progresses [CDAR-447](https://usdot-carma.atlassian.net/browse/CDAR-447)
Closes [CDAR-582](https://usdot-carma.atlassian.net/browse/CDAR-582)

## Motivation and Context

The original library target name was clunky from a user perspective, and the `EXPORT_NAME` property alternative solution deviated from the rest of our projects' conventions.

## How Has This Been Tested?

Manually checked that user libraries have intended side effects.

## Types of changes

- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
