### PR TITLE
Fix making square matrix implementation

### DIFF
--- a/include/multiple_object_tracking/detail/dlib_extensions.hpp
+++ b/include/multiple_object_tracking/detail/dlib_extensions.hpp
@@ -28,9 +28,19 @@ auto make_square_matrix(
     }
   }
 
-  for (auto row{matrix.nr()}; row < square_matrix_size; ++row) {
-    for (auto column{matrix.nc()}; column < square_matrix_size; ++column) {
-      square_matrix(row, column) = padding_value.value;
+  if (matrix.nr() > matrix.nc()) {
+    // We added extra column(s)
+    for (auto row{0U}; row < square_matrix_size; ++row) {
+      for (auto column{matrix.nc()}; column < square_matrix_size; ++column) {
+        square_matrix(row, column) = padding_value.value;
+      }
+    }
+  } else {
+    // We added extra row(s)
+    for (auto row{matrix.nr()}; row < square_matrix_size; ++row) {
+      for (auto column{0U}; column < square_matrix_size; ++column) {
+        square_matrix(row, column) = padding_value.value;
+      }
     }
   }
 

--- a/include/multiple_object_tracking/detail/dlib_extensions.hpp
+++ b/include/multiple_object_tracking/detail/dlib_extensions.hpp
@@ -1,0 +1,42 @@
+#ifndef MULTIPLE_OBJECT_TRACKING_DETAIL_DLIB_EXTENSIONS_HPP
+#define MULTIPLE_OBJECT_TRACKING_DETAIL_DLIB_EXTENSIONS_HPP
+
+#include <dlib/matrix/matrix.h>
+
+namespace multiple_object_tracking::detail
+{
+template <typename Value>
+struct PaddingValue
+{
+  Value value;
+};
+
+template <typename Value>
+PaddingValue(Value) -> PaddingValue<Value>;
+
+template <typename ValueType>
+auto make_square_matrix(
+  const dlib::matrix<ValueType> & matrix, const PaddingValue<ValueType> & padding_value) noexcept
+  -> dlib::matrix<ValueType>
+{
+  const auto square_matrix_size{std::max(matrix.nr(), matrix.nc())};
+  dlib::matrix<ValueType> square_matrix(square_matrix_size, square_matrix_size);
+
+  for (auto row{0U}; row < matrix.nr(); ++row) {
+    for (auto column{0U}; column < matrix.nc(); ++column) {
+      square_matrix(row, column) = matrix(row, column);
+    }
+  }
+
+  for (auto row{matrix.nr()}; row < square_matrix_size; ++row) {
+    for (auto column{matrix.nc()}; column < square_matrix_size; ++column) {
+      square_matrix(row, column) = padding_value.value;
+    }
+  }
+
+  return square_matrix;
+}
+
+}  // namespace multiple_object_tracking::detail
+
+#endif  // MULTIPLE_OBJECT_TRACKING_DETAIL_DLIB_EXTENSIONS_HPP


### PR DESCRIPTION
# PR Details
## Description

This PR fixes an issue that caused incorrect track-to-detection associations for certain scenarios. There was some issue with the implementation for making cost matrices squared. Instead of using dlib::tmp, we are now explicitly creating a new empty matrix then populating the data manually. This operation was also moved into its own function. We can refine the implementation later if needed, but the separate function abstracts the current implementation.

## Related GitHub Issue

Closes #106 

## Related Jira Key

Closes [CDAR-577](https://usdot-carma.atlassian.net/browse/CDAR-577)

## Motivation and Context

## How Has This Been Tested?

Unit tests

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-577]: https://usdot-carma.atlassian.net/browse/CDAR-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ