### PR TITLE
Add track state setter for `FixedThresholdTrackManager`

### DIFF
--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -48,6 +48,13 @@ auto get_timestamp(const std::variant<Alternatives...> & object) -> units::time:
   return std::visit([](const auto & o) { return get_timestamp(o); }, object);
 }
 
+template <typename State, typename StateCovariance, typename Tag>
+auto set_timestamp(
+  DynamicObject<State, StateCovariance, Tag> & object, const units::time::second_t & timestamp)
+{
+  object.timestamp = timestamp;
+}
+
 /**
  * @brief Get the object's UUID
  *
@@ -78,6 +85,39 @@ template <typename... Variants>
 auto get_uuid(const std::variant<Variants...> & object) -> Uuid
 {
   return std::visit([](const auto & o) { return get_uuid(o); }, object);
+}
+
+template <typename State, typename StateCovariance, typename Tag>
+auto set_uuid(DynamicObject<State, StateCovariance, Tag> & object, const Uuid & uuid)
+{
+  object.uuid = uuid;
+}
+
+template <typename State, typename StateCovariance, typename Tag>
+auto set_state(DynamicObject<State, StateCovariance, Tag> & object, const State & state)
+{
+  object.state = state;
+}
+
+template <typename State, typename... Alternatives>
+auto set_state(const std::variant<Alternatives...> & object, const State & state)
+{
+  return std::visit([](const auto & o, const auto & s) { return set_state(o, s); }, object);
+}
+
+template <typename State, typename StateCovariance, typename Tag>
+auto set_state_covariance(
+  DynamicObject<State, StateCovariance, Tag> & object, const StateCovariance & state_covariance)
+{
+  object.covariance = state_covariance;
+}
+
+template <typename StateCovariance, typename... Alternatives>
+auto set_state_covariance(
+  const std::variant<Alternatives...> & object, const StateCovariance & state_covariance)
+{
+  return std::visit(
+    [](const auto & o, const auto & c) { return set_state_covariance(o, c); }, object);
 }
 
 template <typename State, typename StateCovariance>

--- a/include/multiple_object_tracking/track_management.hpp
+++ b/include/multiple_object_tracking/track_management.hpp
@@ -173,6 +173,18 @@ public:
     return removal_threshold_;
   }
 
+  auto update_track(
+    const Uuid track_id, const units::time::second_t & timestamp,
+    const typename Track::state_type & state,
+    const typename Track::state_covariance_type & state_covariance)
+  {
+    auto & track = tracks_.at(track_id);
+
+    set_timestamp(track, timestamp);
+    set_state(track, state);
+    set_state_covariance(track, state_covariance);
+  }
+
 private:
   PromotionThreshold promotion_threshold_;
   RemovalThreshold removal_threshold_;


### PR DESCRIPTION
# PR Details
## Description

This PR adds track update function for the `FixedThresholdTrackManager` class that allows users to update contained tracks in place. Previously, there was no ability for users to modify tracks after they have been added to the manager.

## Related GitHub Issue

Closes #113 
usdot-fhwa-stol/carma-platform#2213

## Related Jira Key

Closes [CDAR-596](https://usdot-carma.atlassian.net/browse/CDAR-596)

## Motivation and Context

There was no way to modify tracks' states, so the manager was less useful than it could be.

## How Has This Been Tested?

Unit tests

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-596]: https://usdot-carma.atlassian.net/browse/CDAR-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ