### PR TITLE
Remove `FixedThresholdTrackManager`'s `update_track` function type specifiers

### DIFF
--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -55,6 +55,12 @@ auto set_timestamp(
   object.timestamp = timestamp;
 }
 
+template <typename... Alternatives>
+auto set_timestamp(const std::variant<Alternatives...> & object)
+{
+  std::visit([](const auto & o) { set_timestamp(o); }, object);
+}
+
 /**
  * @brief Get the object's UUID
  *
@@ -91,6 +97,11 @@ template <typename State, typename StateCovariance, typename Tag>
 auto set_uuid(DynamicObject<State, StateCovariance, Tag> & object, const Uuid & uuid)
 {
   object.uuid = uuid;
+}
+
+template <typename... Alternatives>
+auto set_uuid(const std::variant<Alternatives...> & object) {
+  std::visit([](const auto & o) { set_uuid(o); }, object);
 }
 
 template <typename State, typename StateCovariance, typename Tag>

--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -94,7 +94,9 @@ auto set_uuid(DynamicObject<State, StateCovariance, Tag> & object, const Uuid & 
 }
 
 template <typename State, typename StateCovariance, typename Tag>
-auto set_state(DynamicObject<State, StateCovariance, Tag> & object, const State & state)
+auto set_state(
+  DynamicObject<State, StateCovariance, Tag> & object,
+  const typename DynamicObject<State, StateCovariance, Tag>::state_type & state)
 {
   object.state = state;
 }
@@ -107,7 +109,9 @@ auto set_state(const std::variant<Alternatives...> & object, const State & state
 
 template <typename State, typename StateCovariance, typename Tag>
 auto set_state_covariance(
-  DynamicObject<State, StateCovariance, Tag> & object, const StateCovariance & state_covariance)
+  DynamicObject<State, StateCovariance, Tag> & object,
+  const typename DynamicObject<State, StateCovariance, Tag>::state_covariance_type &
+    state_covariance)
 {
   object.covariance = state_covariance;
 }

--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -151,6 +151,25 @@ auto set_state(std::variant<Alternatives...> & object, const State & state)
 }
 
 template <typename State, typename StateCovariance, typename Tag>
+auto copy_state(
+  DynamicObject<State, StateCovariance, Tag> & destination,
+  const DynamicObject<State, StateCovariance, Tag> & source)
+{
+  destination.state = destination.state;
+}
+
+template <typename... Alternatives>
+auto copy_state(
+  std::variant<Alternatives...> & destination, const std::variant<Alternatives...> & source)
+{
+  std::visit(
+    Visitor{
+      [](auto & dst, const auto & src) { copy_state(dst, src); },
+      [](...) { throw std::runtime_error("source and destination are different types"); }},
+    destination, source);
+}
+
+template <typename State, typename StateCovariance, typename Tag>
 auto get_state_covariance(const DynamicObject<State, StateCovariance, Tag> & object)
 {
   return object.covariance;
@@ -195,14 +214,27 @@ auto set_state_covariance(
   std::variant<Alternatives...> & object, const StateCovariance & state_covariance)
 {
   std::visit(
-    // Visitor{
-    //   [](auto & o, const StateCovariance & c) { set_state_covariance(o, c); },
-    //   [](auto &, const auto &) {
-    //     throw std::runtime_error("state covariance types are incompatible");
-    //   },
-    // },
     detail::set_state_covariance_visitor{}, object,
     std::variant<StateCovariance>{state_covariance});
+}
+
+template <typename State, typename StateCovariance, typename Tag>
+auto copy_state_covariance(
+  DynamicObject<State, StateCovariance, Tag> & destination,
+  const DynamicObject<State, StateCovariance, Tag> & source)
+{
+  destination.covariance = source.covariance;
+}
+
+template <typename... Alternatives>
+auto copy_state_covariance(
+  std::variant<Alternatives...> & destination, const std::variant<Alternatives...> & source)
+{
+  std::visit(
+    Visitor{
+      [](auto & dst, const auto & src) { copy_state_covariance(dst, src); },
+      [](...) { throw std::runtime_error("source and destination are different types"); }},
+    destination, source);
 }
 
 template <typename State, typename StateCovariance>

--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -56,9 +56,9 @@ auto set_timestamp(
 }
 
 template <typename... Alternatives>
-auto set_timestamp(const std::variant<Alternatives...> & object)
+auto set_timestamp(std::variant<Alternatives...> & object, const units::time::second_t & timestamp)
 {
-  std::visit([](const auto & o) { set_timestamp(o); }, object);
+  std::visit([](auto & o, const auto & t) { set_timestamp(o, t); }, object);
 }
 
 /**
@@ -100,8 +100,9 @@ auto set_uuid(DynamicObject<State, StateCovariance, Tag> & object, const Uuid & 
 }
 
 template <typename... Alternatives>
-auto set_uuid(const std::variant<Alternatives...> & object) {
-  std::visit([](const auto & o) { set_uuid(o); }, object);
+auto set_uuid(std::variant<Alternatives...> & object, const Uuid & uuid)
+{
+  std::visit([](auto & o, const auto & u) { set_uuid(o, u); }, object);
 }
 
 template <typename State, typename StateCovariance, typename Tag>
@@ -125,9 +126,9 @@ auto set_state(
 }
 
 template <typename State, typename... Alternatives>
-auto set_state(const std::variant<Alternatives...> & object, const State & state)
+auto set_state(std::variant<Alternatives...> & object, const State & state)
 {
-  return std::visit([](const auto & o, const auto & s) { return set_state(o, s); }, object);
+  std::visit([](auto & o, const auto & s) { set_state(o, s); }, object);
 }
 
 template <typename State, typename StateCovariance, typename Tag>
@@ -153,10 +154,9 @@ auto set_state_covariance(
 
 template <typename StateCovariance, typename... Alternatives>
 auto set_state_covariance(
-  const std::variant<Alternatives...> & object, const StateCovariance & state_covariance)
+  std::variant<Alternatives...> & object, const StateCovariance & state_covariance)
 {
-  return std::visit(
-    [](const auto & o, const auto & c) { return set_state_covariance(o, c); }, object);
+  std::visit([](auto & o, const auto & c) { set_state_covariance(o, c); }, object);
 }
 
 template <typename State, typename StateCovariance>

--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -158,15 +158,32 @@ auto copy_state(
   destination.state = destination.state;
 }
 
+namespace detail
+{
+
+struct copy_state_visitor
+{
+  template <typename State, typename StateCovariance, typename Tag>
+  auto operator()(
+    DynamicObject<State, StateCovariance, Tag> & destination,
+    const DynamicObject<State, StateCovariance, Tag> & source) const
+  {
+    copy_state(destination, source);
+  }
+
+  auto operator()(...) const
+  {
+    throw std::runtime_error("source and destination are different types");
+  }
+};
+
+}  // namespace detail
+
 template <typename... Alternatives>
 auto copy_state(
   std::variant<Alternatives...> & destination, const std::variant<Alternatives...> & source)
 {
-  std::visit(
-    Visitor{
-      [](auto & dst, const auto & src) { copy_state(dst, src); },
-      [](...) { throw std::runtime_error("source and destination are different types"); }},
-    destination, source);
+  std::visit(detail::copy_state_visitor{}, destination, source);
 }
 
 template <typename State, typename StateCovariance, typename Tag>
@@ -226,15 +243,32 @@ auto copy_state_covariance(
   destination.covariance = source.covariance;
 }
 
+namespace detail
+{
+
+struct copy_state_covariance_visitor
+{
+  template <typename State, typename StateCovariance, typename Tag>
+  auto operator()(
+    DynamicObject<State, StateCovariance, Tag> & destination,
+    const DynamicObject<State, StateCovariance, Tag> & source)
+  {
+    copy_state_covariance(destination, source);
+  }
+
+  auto operator()(...) const
+  {
+    throw std::runtime_error("source and destination are different types");
+  }
+};
+
+}  // namespace detail
+
 template <typename... Alternatives>
 auto copy_state_covariance(
   std::variant<Alternatives...> & destination, const std::variant<Alternatives...> & source)
 {
-  std::visit(
-    Visitor{
-      [](auto & dst, const auto & src) { copy_state_covariance(dst, src); },
-      [](...) { throw std::runtime_error("source and destination are different types"); }},
-    destination, source);
+  std::visit(detail::copy_state_covariance_visitor{}, destination, source);
 }
 
 template <typename State, typename StateCovariance>

--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -58,7 +58,9 @@ auto set_timestamp(
 template <typename... Alternatives>
 auto set_timestamp(std::variant<Alternatives...> & object, const units::time::second_t & timestamp)
 {
-  std::visit([](auto & o, const auto & t) { set_timestamp(o, t); }, object);
+  std::visit(
+    [](auto & o, const auto & t) { set_timestamp(o, t); }, object,
+    std::variant<units::time::second_t>{timestamp});
 }
 
 /**
@@ -102,7 +104,7 @@ auto set_uuid(DynamicObject<State, StateCovariance, Tag> & object, const Uuid & 
 template <typename... Alternatives>
 auto set_uuid(std::variant<Alternatives...> & object, const Uuid & uuid)
 {
-  std::visit([](auto & o, const auto & u) { set_uuid(o, u); }, object);
+  std::visit([](auto & o, const auto & u) { set_uuid(o, u); }, object, std::variant<Uuid>{uuid});
 }
 
 template <typename State, typename StateCovariance, typename Tag>
@@ -128,7 +130,7 @@ auto set_state(
 template <typename State, typename... Alternatives>
 auto set_state(std::variant<Alternatives...> & object, const State & state)
 {
-  std::visit([](auto & o, const auto & s) { set_state(o, s); }, object);
+  std::visit([](auto & o, const auto & s) { set_state(o, s); }, object, std::variant<State>{state});
 }
 
 template <typename State, typename StateCovariance, typename Tag>
@@ -156,7 +158,9 @@ template <typename StateCovariance, typename... Alternatives>
 auto set_state_covariance(
   std::variant<Alternatives...> & object, const StateCovariance & state_covariance)
 {
-  std::visit([](auto & o, const auto & c) { set_state_covariance(o, c); }, object);
+  std::visit(
+    [](auto & o, const auto & c) { set_state_covariance(o, c); }, object,
+    std::variant<StateCovariance>{state_covariance});
 }
 
 template <typename State, typename StateCovariance>

--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -94,6 +94,18 @@ auto set_uuid(DynamicObject<State, StateCovariance, Tag> & object, const Uuid & 
 }
 
 template <typename State, typename StateCovariance, typename Tag>
+auto get_state(const DynamicObject<State, StateCovariance, Tag> & object)
+{
+  return object.state;
+}
+
+template <typename... Alternatives>
+auto get_state(const std::variant<Alternatives...> & object)
+{
+  return std::visit([](const auto & o) { return get_state(o); }, object);
+}
+
+template <typename State, typename StateCovariance, typename Tag>
 auto set_state(
   DynamicObject<State, StateCovariance, Tag> & object,
   const typename DynamicObject<State, StateCovariance, Tag>::state_type & state)
@@ -105,6 +117,18 @@ template <typename State, typename... Alternatives>
 auto set_state(const std::variant<Alternatives...> & object, const State & state)
 {
   return std::visit([](const auto & o, const auto & s) { return set_state(o, s); }, object);
+}
+
+template <typename State, typename StateCovariance, typename Tag>
+auto get_state_covariance(const DynamicObject<State, StateCovariance, Tag> & object)
+{
+  return object.covariance;
+}
+
+template <typename... Alternatives>
+auto get_state_covariance(const std::variant<Alternatives...> & object)
+{
+  return std::visit([](const auto & o) { return get_state_covariance(o); }, object);
 }
 
 template <typename State, typename StateCovariance, typename Tag>
@@ -131,9 +155,15 @@ template <typename State, typename StateCovariance>
 using Track = DynamicObject<State, StateCovariance, struct TrackTag>;
 
 template <typename Track, typename Detection>
+auto make_track(const Detection & detection, const Uuid & uuid) -> Track
+{
+  return {detection.timestamp, detection.state, detection.covariance, uuid};
+}
+
+template <typename Track, typename Detection>
 auto make_track(const Detection & detection) -> Track
 {
-  return {detection.timestamp, detection.state, detection.covariance, detection.uuid};
+  return make_track<Track>(detection, detection.uuid);
 }
 
 template <typename Track, typename... Alternatives>

--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -155,7 +155,7 @@ auto copy_state(
   DynamicObject<State, StateCovariance, Tag> & destination,
   const DynamicObject<State, StateCovariance, Tag> & source)
 {
-  destination.state = destination.state;
+  destination.state = source.state;
 }
 
 namespace detail

--- a/include/multiple_object_tracking/track_management.hpp
+++ b/include/multiple_object_tracking/track_management.hpp
@@ -173,10 +173,10 @@ public:
     return removal_threshold_;
   }
 
+  template <typename State, typename StateCovariance>
   auto update_track(
-    const Uuid track_id, const units::time::second_t & timestamp,
-    const typename Track::state_type & state,
-    const typename Track::state_covariance_type & state_covariance)
+    const Uuid track_id, const units::time::second_t & timestamp, const State & state,
+    const StateCovariance & state_covariance)
   {
     auto & track = tracks_.at(track_id);
 

--- a/include/multiple_object_tracking/track_management.hpp
+++ b/include/multiple_object_tracking/track_management.hpp
@@ -185,6 +185,13 @@ public:
     set_state_covariance(track, state_covariance);
   }
 
+  auto update_track(const Uuid track_id, const Track & track)
+  {
+    set_timestamp(tracks_.at(track_id), get_timestamp(track));
+    copy_state(tracks_.at(track_id), track);
+    copy_state_covariance(tracks_.at(track_id), track);
+  }
+
 private:
   PromotionThreshold promotion_threshold_;
   RemovalThreshold removal_threshold_;


### PR DESCRIPTION
# PR Details
## Description

This PR modifies the `FixedThresholdTrackManager` to support `std::variant` types.

The track manager's update_track function used the state_type and state_covariance_type member aliases for the function parameter types, but std::variant track types don't work with this. It's easier to remove those type requirements and refactor later.

The `state` and `state_covariance` types are now template parameters. 

## Related GitHub Issue

Closes #115 

## Related Jira Key

Closes [CDAR-596](https://usdot-carma.atlassian.net/browse/CDAR-596)

## Motivation and Context

Add support for `std::variant` types.

## How Has This Been Tested?

Unit tests. Manual integration test with downstream project.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-596]: https://usdot-carma.atlassian.net/browse/CDAR-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ