### PR TITLE
Add bounds check for creating associations

### DIFF
--- a/include/multiple_object_tracking/track_matching.hpp
+++ b/include/multiple_object_tracking/track_matching.hpp
@@ -194,6 +194,11 @@ inline auto association_map_from_score_map(
 
   // Iterate over the assignments and populate the AssociationMap
   for (int i = 0; i < assignments.size(); i++) {
+    if (assignments[i] >= std::size(detection_set)) {
+      // Indices greater than the number of detections indicate that the track did not get assigned
+      continue;
+    }
+
     // Get the track UUID at the current index
     const auto & track_uuid = get_element_at(track_set, i);
 


### PR DESCRIPTION
# PR Details
## Description

This PR resolves a bug when doing the track-to-detection association step with more tracks than detections. When creating association maps from the association problem results, there was no bounds checking. This would cause an indexing error when there are existing tracks that did not get any associated detections.

## Related GitHub Issue

Closes #111 

## Related Jira Key

Closes [CDAR-586](https://usdot-carma.atlassian.net/browse/CDAR-586)

## Motivation and Context

Fixes bug

## How Has This Been Tested?

Unit tests. Integration tests.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-586]: https://usdot-carma.atlassian.net/browse/CDAR-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ