### PR TITLE
Add semantic class field for dynamic object

### DIFF
--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -24,6 +24,15 @@
 
 namespace multiple_object_tracking
 {
+enum class SemanticClass
+{
+  kUnknown,
+  kSmallVehicle,
+  kLargeVehicle,
+  kPedestrian,
+  kMotorcycle
+};
+
 template <typename State, typename StateCovariance, typename Tag>
 struct DynamicObject
 {
@@ -35,6 +44,7 @@ struct DynamicObject
   State state{};
   StateCovariance covariance{};
   Uuid uuid{""};
+  SemanticClass semantic_class{SemanticClass::kUnknown};
 };
 
 template <typename Object>
@@ -106,6 +116,34 @@ template <typename... Alternatives>
 auto set_uuid(std::variant<Alternatives...> & object, const Uuid & uuid)
 {
   std::visit([](auto & o, const Uuid & u) { set_uuid(o, u); }, object, std::variant<Uuid>{uuid});
+}
+
+template <typename State, typename StateCovariance, typename Tag>
+auto get_semantic_class(const DynamicObject<State, StateCovariance, Tag> & object)
+{
+  return object.semantic_class;
+}
+
+template <typename... Alternatives>
+auto get_semantic_class(const std::variant<Alternatives...> & object)
+{
+  return std::visit([](const auto & o) { return get_semantic_class(o); }, object);
+}
+
+template <typename State, typename StateCovariance, typename Tag>
+auto set_semantic_class(
+  DynamicObject<State, StateCovariance, Tag> & object, const SemanticClass & semantic_class)
+{
+  object.semantic_class = semantic_class;
+}
+
+template <typename... Alternatives>
+auto set_semantic_class(
+  std::variant<Alternatives...> & object, const SemanticClass & semantic_class)
+{
+  std::visit(
+    [](auto & o, const auto & c) { set_semantic_class(o, c); }, object,
+    std::variant<SemanticClass>(semantic_class));
 }
 
 template <typename State, typename StateCovariance, typename Tag>


### PR DESCRIPTION
# PR Details
## Description

This PR adds a semantic class field for the `DynamicObject` class. Semantic class information is useful for a variety of applications and is a pretty common attribute (at least for our use cases).

## Related GitHub Issue

Closes #120 

## Related Jira Key

Closes [CDAR-627](https://usdot-carma.atlassian.net/browse/CDAR-627)

## Motivation and Context

See above

## How Has This Been Tested?

Manually in integration tests.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-627]: https://usdot-carma.atlassian.net/browse/CDAR-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ