### PR TITLE
Add clustering overload for generic metric

### DIFF
--- a/include/multiple_object_tracking/clustering.hpp
+++ b/include/multiple_object_tracking/clustering.hpp
@@ -211,8 +211,9 @@ auto make_point(const std::variant<Alternatives...> & detection) -> Point
 
 }  // namespace detail
 
-template <typename Detection>
-[[nodiscard]] auto cluster_detections(std::vector<Detection> detections, double distance_threshold)
+template <typename Detection, typename Metric>
+[[nodiscard]] auto cluster_detections(
+  std::vector<Detection> detections, double distance_threshold, Metric metric)
   -> std::vector<Cluster<Detection>>
 {
   std::vector<Cluster<Detection>> clusters;
@@ -227,7 +228,7 @@ template <typename Detection>
     detections.pop_back();
 
     for (auto it{std::begin(detections)}; it != std::end(detections);) {
-      if (detail::squared_euclidean_distance(origin_point, *it) < distance_threshold) {
+      if (metric(origin_point, *it) < distance_threshold) {
         cluster.add_detection(*it);
         it = detections.erase(it);
       } else {
@@ -239,6 +240,12 @@ template <typename Detection>
   }
 
   return clusters;
+}
+
+template <typename Detection>
+[[nodiscard]] auto cluster_detections(std::vector<Detection> detections, double distance_threshold)
+{
+  return cluster_detections(detections, distance_threshold, detail::squared_euclidean_distance);
 }
 
 }  // namespace multiple_object_tracking

--- a/include/multiple_object_tracking/clustering.hpp
+++ b/include/multiple_object_tracking/clustering.hpp
@@ -211,6 +211,19 @@ auto make_point(const std::variant<Alternatives...> & detection) -> Point
 
 }  // namespace detail
 
+/**
+ * @brief Group detections into clusters
+ *
+ * @tparam Detection Detection type being clustered
+ * @tparam Metric Function comparing cluster centroid with a detection
+ *
+ * @param[in] detections Detections to cluster
+ * @param[in] distance_threshold Distance threshold determining if a detection should be part of
+ * an existing cluster
+ * @param[in] metric Distance metric function object
+ *
+ * @return Generated clusters
+*/
 template <typename Detection, typename Metric>
 [[nodiscard]] auto cluster_detections(
   std::vector<Detection> detections, double distance_threshold, Metric metric)
@@ -242,6 +255,17 @@ template <typename Detection, typename Metric>
   return clusters;
 }
 
+/**
+ * @brief Group detections into clusters using the square Euclidean distance
+ *
+ * @tparam Detection Detection type being clustered
+ *
+ * @param[in] detections Detections to cluster
+ * @param[in] distance_threshold Distance threshold determining if a detection should be part of
+ * an existing cluster
+ *
+ * @return Generated clusters
+*/
 template <typename Detection>
 [[nodiscard]] auto cluster_detections(std::vector<Detection> detections, double distance_threshold)
 {


### PR DESCRIPTION
# PR Details
## Description

The `cluster_detections` function used to hardcode the metric type. Now there is an overload for users to bring their own.

## Related GitHub Issue

Closes #126

## Related Jira Key

Closes [CDAR-700](https://usdot-carma.atlassian.net/browse/CDAR-700)

## Motivation and Context

Not all users will want to use scaled Euclidean distance when generating clusters. Previously, the `cluster_detections` function did not allow users to bring their own metrics.

## How Has This Been Tested?

Manually in downstream packages.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-700]: https://usdot-carma.atlassian.net/browse/CDAR-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ