### PR TITLE
Increase scaled cost value range

### DIFF
--- a/include/multiple_object_tracking/track_matching.hpp
+++ b/include/multiple_object_tracking/track_matching.hpp
@@ -141,7 +141,7 @@ inline auto cost_matrix_from_score_matrix(const dlib::matrix<float> & score_matr
       const float cost_value = 1.0 - normalized_score;
 
       // Scale the cost value by multiplying it by 100 and convert it to an integer
-      const int scaled_cost = static_cast<int>(cost_value * 100);
+      const int scaled_cost = static_cast<int>(cost_value * 100000000);
 
       // Assign the scaled cost to the cost matrix
       cost_matrix(r, c) = scaled_cost;

--- a/include/multiple_object_tracking/track_matching.hpp
+++ b/include/multiple_object_tracking/track_matching.hpp
@@ -140,7 +140,7 @@ inline auto cost_matrix_from_score_matrix(const dlib::matrix<float> & score_matr
       // Calculate the cost value by subtracting the normalized score from 1
       const float cost_value = 1.0 - normalized_score;
 
-      // Scale the cost value by multiplying it by 100 and convert it to an integer
+      // dlib requires integer costs; scaling keeps floating-point costs distinguishable
       const int scaled_cost = static_cast<int>(cost_value * 100000000);
 
       // Assign the scaled cost to the cost matrix


### PR DESCRIPTION
# PR Details
## Description

This PR fixes a bug with track-to-detection cost matrix generation. When generating to cost matrix for track-to-detection scoring, the value range was only 0-100, causing some scores with different floating-point values to get mapped to the same integer value. The integer value range is now between 0-100,000,000.

## Related GitHub Issue

Closes #112 

## Related Jira Key

Closes [CDAR-587](https://usdot-carma.atlassian.net/browse/CDAR-587)

## Motivation and Context

Bug fix

## How Has This Been Tested?

Manually in downstream packages

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-587]: https://usdot-carma.atlassian.net/browse/CDAR-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ