### PR TITLE
Update fused track's timestamp

### DIFF
--- a/include/multiple_object_tracking/fusing.hpp
+++ b/include/multiple_object_tracking/fusing.hpp
@@ -111,6 +111,7 @@ constexpr Visitor covariance_intersection_visitor{
 
     // Create a new fused track with updated state and covariance
     auto fused_track{track};
+    fused_track.timestamp = detection.timestamp;
     fused_track.state = track.state.from_eigen_vector(fused_state);
     fused_track.covariance = fused_covariance;
 


### PR DESCRIPTION
# PR Details
## Description

This PR fixes a bug for covariance intersection. It was previously not updating the timestamp, so the fused track was using it's original stamp.

## Related GitHub Issue

Closes #129 

## Related Jira Key

[CDAR-701](https://usdot-carma.atlassian.net/browse/CDAR-701)

## Motivation and Context

Bug fix

## How Has This Been Tested?

Manually in downstream package.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-701]: https://usdot-carma.atlassian.net/browse/CDAR-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ