### PR TITLE
Copy semantic class when making track

### DIFF
--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -318,7 +318,8 @@ using Track = DynamicObject<State, StateCovariance, struct TrackTag>;
 template <typename Track, typename Detection>
 auto make_track(const Detection & detection, const Uuid & uuid) -> Track
 {
-  return {detection.timestamp, detection.state, detection.covariance, uuid};
+  return {
+    detection.timestamp, detection.state, detection.covariance, uuid, detection.semantic_class};
 }
 
 template <typename Track, typename Detection>


### PR DESCRIPTION
# PR Details
## Description

This PR fixes a bug that causes tracks generated from detections to have possibly invalid semantic classes. The `make_track` function now copies the semantic class from the source detection.

## Related GitHub Issue

Closes #131 

## Related Jira Key

Closes [CDAR-702](https://usdot-carma.atlassian.net/browse/CDAR-702)

## Motivation and Context

Bug fix

## How Has This Been Tested?

Manually in downstream package.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-702]: https://usdot-carma.atlassian.net/browse/CDAR-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ