### PR TITLE
Update GMock matchers to use older API

### DIFF
--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -17,8 +17,5 @@ find_package(dlib REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(Boost REQUIRED COMPONENTS container)
 if(multiple_object_tracking_ENABLE_TESTING OR PROJECT_IS_TOP_LEVEL)
-  # Currently findGTest does not currently actually work well for version
-  # so if you have compilation issues ensure you have the correct version
-  # installed
-  find_package(GTest 1.14.0 REQUIRED)
+  find_package(GTest REQUIRED)
 endif()


### PR DESCRIPTION
# PR Details
## Description

The GMock matchers were implemented using a newer API that is incompatible with GMock version 1.10. Since most downstream packages (namely, CARMA packages) still use version 1.10, it would be best to revert back to that implementation.

## Related GitHub Issue

Closes #134 

## Related Jira Key

Closes [CDAR-703](https://usdot-carma.atlassian.net/browse/CDAR-703)

## Motivation and Context

This was preventing downstream, dependent project from building.

## How Has This Been Tested?

Manually.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.


[CDAR-703]: https://usdot-carma.atlassian.net/browse/CDAR-703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ