### PR TITLE
Include <variant>

### DIFF
--- a/include/multiple_object_tracking/dynamic_object.hpp
+++ b/include/multiple_object_tracking/dynamic_object.hpp
@@ -17,6 +17,8 @@
 #ifndef MULTIPLE_OBJECT_TRACKING_DYNAMIC_OBJECT_HPP
 #define MULTIPLE_OBJECT_TRACKING_DYNAMIC_OBJECT_HPP
 
+#include <variant>
+
 #include <units.h>
 
 #include "multiple_object_tracking/uuid.hpp"


### PR DESCRIPTION
# PR Details
## Description

Adds missing `#include <variant>` to `dynamic_object.hpp`

## Related GitHub Issue

Closes #136 

## Related Jira Key

Closes [CDAR-704](https://usdot-carma.atlassian.net/browse/CDAR-704)

## Motivation and Context

Compilation error

## How Has This Been Tested?

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-704]: https://usdot-carma.atlassian.net/browse/CDAR-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ