### PR TITLE
Change Eigen to apt dependency

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
 
-# Install eigen
 set -ex
-cd /tmp
-git clone --depth 1 --branch 3.4.0 https://gitlab.com/libeigen/eigen.git /tmp/eigen
-cd /tmp/eigen
-cmake -B build -DCMAKE_BUILD_TYPE=Release -DEIGEN_BUILD_TESTING=OFF -DEIGEN_BUILD_DOC=OFF
-cmake --build build
-cmake --install build
-cd /
-rm -rf /tmp/eigen
 
 # Install dlib
 git clone --depth 1 --branch v19.24.2 https://github.com/davisking/dlib.git /tmp/dlib
@@ -50,11 +41,10 @@ cmake -B build  \
     -DJSON_BuildTests=FALSE \
     -DJSON_Install=TRUE \
     -DBUILD_DOCS=OFF
-
 cmake --build build
 cmake --install build
 cd /
 rm -rf /tmp/json
 
 apt update
-DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends libboost-container-dev
+DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends libboost-container-dev libeigen3-dev


### PR DESCRIPTION
# PR Details
## Description

This PR changes the Eigen dependency from being installed from source to being installed by apt. The installed version has also been reduced (implicitly) from 3.4 to 3.3.

## Related GitHub Issue

Closes #141 

## Related Jira Key

Closes [CDAR-713](https://usdot-carma.atlassian.net/browse/CDAR-712)

## Motivation and Context

Most of our environments install Eigen 3.3, so it would be easier to install through apt.

## How Has This Been Tested?

## Types of changes

- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.



[CDAR-713]: https://usdot-carma.atlassian.net/browse/CDAR-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ