### PR TITLE
Fix track manager's handling of confirmed tracks

### DIFF
--- a/include/multiple_object_tracking/track_management.hpp
+++ b/include/multiple_object_tracking/track_management.hpp
@@ -54,7 +54,8 @@ public:
   {
   }
 
-  auto get_occurrences(const Uuid & uuid) const {
+  auto get_occurrences(const Uuid & uuid) const
+  {
     if (occurrences_.count(uuid) == 0) {
       return 0;
     }
@@ -69,7 +70,6 @@ public:
         --occurrences;
       } else {
         occurrences = std::min(occurrences + 1, promotion_threshold_.value);
-        // ++occurrences;
       }
     }
 
@@ -87,9 +87,6 @@ public:
       if (occurrences >= promotion_threshold_.value) {
         statuses_.at(uuid) = TrackStatus::kConfirmed;
       }
-      // else {
-      //   statuses_.at(uuid) = TrackStatus::kTentative;
-      // }
 
       ++it;
     }

--- a/include/multiple_object_tracking/track_management.hpp
+++ b/include/multiple_object_tracking/track_management.hpp
@@ -52,6 +52,14 @@ public:
   {
   }
 
+  auto get_occurrences(const Uuid & uuid) const {
+    if (occurrences_.count(uuid) == 0) {
+      return 0;
+    }
+
+    return static_cast<int>(occurrences_.at(uuid));
+  }
+
   auto update_track_lists(const AssociationMap & associations) -> void
   {
     for (auto & [uuid, occurrences] : occurrences_) {

--- a/include/multiple_object_tracking/track_management.hpp
+++ b/include/multiple_object_tracking/track_management.hpp
@@ -68,7 +68,7 @@ public:
       if (associations.count(uuid) == 0) {
         --occurrences;
       } else {
-        occurrences = std::max(occurrences + 1, promotion_threshold_);
+        occurrences = std::max(occurrences + 1, promotion_threshold_.value);
         // ++occurrences;
       }
     }

--- a/include/multiple_object_tracking/track_management.hpp
+++ b/include/multiple_object_tracking/track_management.hpp
@@ -66,7 +66,8 @@ public:
       if (associations.count(uuid) == 0) {
         --occurrences;
       } else {
-        ++occurrences;
+        occurrences = std::max(occurrences + 1, promotion_threshold_);
+        // ++occurrences;
       }
     }
 

--- a/include/multiple_object_tracking/track_management.hpp
+++ b/include/multiple_object_tracking/track_management.hpp
@@ -68,7 +68,7 @@ public:
       if (associations.count(uuid) == 0) {
         --occurrences;
       } else {
-        occurrences = std::max(occurrences + 1, promotion_threshold_.value);
+        occurrences = std::min(occurrences + 1, promotion_threshold_.value);
         // ++occurrences;
       }
     }

--- a/include/multiple_object_tracking/track_management.hpp
+++ b/include/multiple_object_tracking/track_management.hpp
@@ -22,6 +22,8 @@
 #ifndef MULTIPLE_OBJECT_TRACKING_TRACK_MANAGEMENT_HPP
 #define MULTIPLE_OBJECT_TRACKING_TRACK_MANAGEMENT_HPP
 
+#include <algorithm>
+
 #include "multiple_object_tracking/track_matching.hpp"
 #include "multiple_object_tracking/uuid.hpp"
 

--- a/include/multiple_object_tracking/track_management.hpp
+++ b/include/multiple_object_tracking/track_management.hpp
@@ -86,9 +86,10 @@ public:
 
       if (occurrences >= promotion_threshold_.value) {
         statuses_.at(uuid) = TrackStatus::kConfirmed;
-      } else {
-        statuses_.at(uuid) = TrackStatus::kTentative;
       }
+      // else {
+      //   statuses_.at(uuid) = TrackStatus::kTentative;
+      // }
 
       ++it;
     }


### PR DESCRIPTION
# PR Details
## Description

This PR changes how the track manager demotes/removes confirmed tracks. In the proposed implementation change, _confirmed_ tracks never get demoted to _tentative_. _Confirmed_ tracks have a high probability of existing, so they likely have disappeared once we stop receiving associated detections. In this case, we want to stop managing that track entirely. If the same object appears again, we will create a new track for it.

_Confirmed_ tracks will now be removed if they don't receive an association in a specified number of times in a row. Additionally, there is an occurrence count cap. This is to prevent occurrence counts from reaching large numbers, which prevents invalid tracks from being removed in a timely manner. This was the original bug that this PR resolves.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-801](https://usdot-carma.atlassian.net/browse/CDAR-801)

## Motivation and Context

Bug fix

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-801]: https://usdot-carma.atlassian.net/browse/CDAR-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ