### PR TITLE
Fix unit test track managemet

### DIFF
--- a/test/test_track_management.cpp
+++ b/test/test_track_management.cpp
@@ -50,21 +50,21 @@ TEST(TestTrackManagement, Simple)
 
   track_manager.update_track_lists(association_map);
 
-  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U); 
   EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 1U);
   EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
 
   track_manager.update_track_lists(mot::AssociationMap{});
 
-  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 1U);
-  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U); //confirmed tracks don't get demoted to tentative
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 1U); 
   EXPECT_EQ(std::size(track_manager.get_all_tracks()), 1U);
 
   track_manager.update_track_lists(mot::AssociationMap{});
   track_manager.update_track_lists(mot::AssociationMap{});
 
-  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U);
-  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U);
+  EXPECT_EQ(std::size(track_manager.get_tentative_tracks()), 0U); 
+  EXPECT_EQ(std::size(track_manager.get_confirmed_tracks()), 0U); //confirmed tracks get destroyed after removal threshold is met
   EXPECT_EQ(std::size(track_manager.get_all_tracks()), 0U);
 }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
in this PR, https://github.com/usdot-fhwa-stol/multiple_object_tracking/pull/146
we updated how track manager treats confirmed tracks. This PR is to fix the unit test according to that

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CDAR-801
<!-- e.g. CAR-123 -->

## Motivation and Context
master release prep for 4.5.0
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
