### PR TITLE
CDAD-105: Repurpose CP Track removal parameter

### DIFF
--- a/docs/track_management/fixed_threshold_track_manager/main.md
+++ b/docs/track_management/fixed_threshold_track_manager/main.md
@@ -19,12 +19,12 @@ template <
 | [(constructor)][constructor_doc]                         | constructs the `FixedThresholdTrackManager` |
 | [(destructor)][destructor_doc]                           | destructs the `FixedThresholdTrackManager`  |
 | [`get_promotion_threshold`][get_promotion_threshold_doc] | gets the current promotion threshold        |
-| [`get_removal_threshold`][get_removal_threshold_doc]     | gets the current removal threshold          |
+| [`get_confirmed_to_removal_threshold`][get_confirmed_to_removal_threshold_doc] | gets the number of consecutive nonoccurence of confirmed track to be verified for removal|
 
 [constructor_doc]: constructor.md
 [destructor_doc]: destructor.md
 [get_promotion_threshold_doc]: get_promotion_threshold.md
-[get_removal_threshold_doc]: get_removal_threshold.md
+[get_confirmed_to_removal_threshold_doc]: get_confirmed_to_removal_threshold.md
 
 ### Track access
 
@@ -34,13 +34,13 @@ template <
 | [`get_confirmed_tracks`][get_confirmed_tracks_doc]                             | access a list of tracks whose status is _confirmed_      |
 | [`get_all_tracks`][get_all_tracks_doc]                                         | access a list of all managed tracks regardless of status |
 | [`set_promotion_threshold_and_update`][set_promotion_threshold_and_update_doc] | set a new promotion threshold and update track statuses  |
-| [`set_removal_threshold_and_update`][set_promotion_threshold_and_update_doc]   | set a new removal threshold and update track list        |
+| [`set_confirmed_to_removal_threshold_and_update`][set_promotion_threshold_and_update_doc]   | set a new removal threshold and update track list        |
 
 [get_tentative_tracks_doc]: get_tentative_tracks.md
 [get_confirmed_tracks_doc]: get_confirmed_tracks.md
 [get_all_tracks_doc]: get_all_tracks.md
 [set_promotion_threshold_and_update_doc]: set_promotion_threshold_and_update.md
-[set_removal_threshold_and_update_doc]: set_removal_threshold_and_update.md
+[set_confirmed_to_removal_threshold_and_update_doc]: set_confirmed_to_removal_threshold_and_update.md
 
 ### Modifiers
 

--- a/docs/track_management/fixed_threshold_track_manager/set_removal_threshold_and_update.md
+++ b/docs/track_management/fixed_threshold_track_manager/set_removal_threshold_and_update.md
@@ -1,14 +1,15 @@
-# `multiple_object_tracking::FixedThresholdTrackManager<Track>::set_removal_threshold_and_update`
+# `multiple_object_tracking::FixedThresholdTrackManager<Track>::set_confirmed_to_removal_threshold_and_update`
 
 ```cpp
-auto set_removal_threshold_and_update(const RemovalThreshold & threshold) noexcept -> void;
+auto set_confirmed_to_removal_threshold_and_update(const RemovalThreshold & threshold) noexcept -> void;
 ```
 
 Sets the removal threshold to a new value and prunes tracks based on the new threshold.
 
 ## Parameters
 
-- `threshold` - occurrence threshold at or below which a detection will be removed from management
+- `threshold` - nonoccurrence threshold at or more which a Track is consecutively missed to be tagged for removal
+NOTE: Detections get removed at occurrence 0 by default.
 
 ## Return value
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR makes the threshold to be for different meaning. 
Currently removal threshold is not really useful and hard to understand if it's other than 0. Tracks are dropped below this number of occurrence. Since internal data structure uses unsigned int, the removal threshold is bound between 0 and promotion_threshold. 

Instead, we should hard code to drop the Track if below 0 counter. And we should repurpose the parameter to specify how many consecutive iteration will it take for non-confirmed track to be dropped.  This way, the Confirmed Track can be tracked for a longer time (imagine the object going after an obstruction briefly, we should aim to track it as long as we can for ADS purpose). This is because downstream components don't have that "memory" capability and will blindly accept CP's outputs. 
 
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
CDAD-105
<!-- e.g. CAR-123 -->

## Motivation and Context
Sometimes, infrastructure's SDSM could be missed for 0.5s. I wanted to cover that range, but I cannot make the threshold lower than 0. And if I increase the promotion_threshold, since the 2 parameter is tightly coupled, it would have also taken more time to verify the it is Confirmed despite taking longer to remove.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
